### PR TITLE
perf: reduz delay entre overlay e captura real de audio (#16)

### DIFF
--- a/Tests/IntegrationTests.swift
+++ b/Tests/IntegrationTests.swift
@@ -59,39 +59,39 @@ struct IntegrationTests {
 
     // MARK: - 3. Transições de estado
 
-    @Test("Fluxo idle → recording quando pré-requisitos atendidos")
+    @Test("Fluxo idle → preparing quando pré-requisitos atendidos")
     func testStateTransitions() {
         let appState = makeReadyAppState()
 
         #expect(appState.state == .idle, "Estado inicial deve ser idle")
         #expect(appState.errorMessage == nil)
 
-        // Toggle deve transicionar para recording
+        // Toggle deve transicionar para preparing (engine ainda não capturou 1º sample)
         appState.toggleRecording()
 
-        #expect(appState.state == .recording, "Deve transicionar para recording")
+        #expect(appState.isRecordingOrPreparing, "Deve transicionar para preparing ou recording")
         #expect(appState.errorMessage == nil, "Não deve ter erro quando pré-requisitos ok")
     }
 
-    @Test("startRecordingIfIdle transiciona para recording quando idle e pré-requisitos ok")
+    @Test("startRecordingIfIdle transiciona para preparing/recording quando idle e pré-requisitos ok")
     func testStartRecordingIfIdleTransitions() {
         let appState = makeReadyAppState()
 
         appState.startRecordingIfIdle()
 
-        #expect(appState.state == .recording)
+        #expect(appState.isRecordingOrPreparing)
         #expect(appState.errorMessage == nil)
     }
 
-    @Test("startRecordingIfIdle não faz nada quando já está recording")
+    @Test("startRecordingIfIdle não faz nada quando já está gravando/preparando")
     func testStartRecordingIfIdleWhenRecording() {
         let appState = makeReadyAppState()
         appState.toggleRecording()
-        #expect(appState.state == .recording)
+        #expect(appState.isRecordingOrPreparing)
 
-        // Segunda chamada não deve causar erro
+        // Segunda chamada não deve causar erro nem alterar estado base
         appState.startRecordingIfIdle()
-        #expect(appState.state == .recording)
+        #expect(appState.isRecordingOrPreparing)
     }
 
     @Test("startRecordingIfIdle não faz nada quando está processing")
@@ -105,20 +105,20 @@ struct IntegrationTests {
 
     // MARK: - 4. Cancelamento durante gravação
 
-    @Test("cancelRecording durante recording deve voltar para idle")
+    @Test("cancelRecording durante preparing/recording deve voltar para idle")
     func testCancelRecordingFromRecording() async throws {
         let appState = makeReadyAppState()
 
         // Inicia gravação
         appState.toggleRecording()
-        #expect(appState.state == .recording)
+        #expect(appState.isRecordingOrPreparing)
 
         // Cancela
         appState.cancelRecording()
 
         // cancelRecording usa Task interno, aguardar a transição
         try await waitUntilOnMain(timeout: .seconds(3)) {
-            appState.state != .recording
+            !appState.isRecordingOrPreparing
         }
 
         #expect(appState.state == .idle, "Deve voltar para idle após cancelamento")
@@ -213,7 +213,7 @@ struct IntegrationTests {
 
         appState.toggleRecording()
 
-        #expect(appState.state == .recording)
+        #expect(appState.isRecordingOrPreparing)
         #expect(appState.errorMessage == nil, "Erro anterior deve ser limpo ao gravar com sucesso")
     }
 
@@ -225,7 +225,7 @@ struct IntegrationTests {
 
         // Simula hold mode: key-down → key-up imediato
         appState.startRecordingIfIdle()
-        #expect(appState.state == .recording)
+        #expect(appState.isRecordingOrPreparing)
 
         appState.stopRecordingIfActive()
 
@@ -234,12 +234,12 @@ struct IntegrationTests {
         // Em ambiente de teste, o estado final pode ser .idle ou .processing
         // dependendo da disponibilidade do microfone — o importante é NÃO crashar
         try await waitUntilOnMain(timeout: .seconds(3)) {
-            appState.state != .recording
+            !appState.isRecordingOrPreparing
         }
 
         // Aceita .idle (mic disponível) ou .processing (mic indisponível, task pendente)
         let validStates: [AppState.RecordingState] = [.idle, .processing]
-        #expect(validStates.contains(appState.state), "Deve estar em idle ou processing, não recording")
+        #expect(validStates.contains(appState.state), "Deve estar em idle ou processing")
     }
 
     @Test("cancelRecording imediatamente após startRecording não deve crashar")
@@ -247,7 +247,7 @@ struct IntegrationTests {
         let appState = makeReadyAppState()
 
         appState.startRecordingIfIdle()
-        #expect(appState.state == .recording)
+        #expect(appState.isRecordingOrPreparing)
 
         appState.cancelRecording()
 
@@ -261,15 +261,15 @@ struct IntegrationTests {
 
         for _ in 0..<5 {
             appState.startRecordingIfIdle()
-            // Só chama stop se realmente entrou em recording
-            if appState.state == .recording {
+            // Só chama stop se realmente entrou em preparing/recording
+            if appState.isRecordingOrPreparing {
                 appState.stopRecordingIfActive()
             }
         }
 
         // Aguarda resolução (com tolerância para hardware indisponível)
         try await waitUntilOnMain(timeout: .seconds(3)) {
-            appState.state != .recording
+            !appState.isRecordingOrPreparing
         }
 
         let validStates: [AppState.RecordingState] = [.idle, .processing]
@@ -299,15 +299,15 @@ struct IntegrationTests {
         ]
 
         appState.toggleRecording()
-        #expect(appState.state == .recording)
+        #expect(appState.isRecordingOrPreparing)
 
-        // Aguarda recordingTask percorrer candidato invalido + cair para default
+        // Aguarda recordingTask percorrer candidato invalido + cair para default + 1º sample
         try await waitUntilOnMain(timeout: .seconds(5)) {
             appState.microphoneManager.activeMicrophoneID == nil
                 && appState.state == .recording
         }
 
-        // Fallback aconteceu: ID ativo e nil (indicando default), estado ainda recording
+        // Fallback aconteceu: ID ativo e nil (indicando default), estado = recording
         #expect(appState.microphoneManager.activeMicrophoneID == nil)
         #expect(appState.state == .recording)
         #expect(appState.errorMessage == nil)

--- a/zspeak/App.swift
+++ b/zspeak/App.swift
@@ -96,8 +96,11 @@ final class OverlayController {
         // Nota: o tamanho do panel é auto-ajustado via KVO em OverlayPanel
         // (NSHostingController.preferredContentSize → adjustToPreferredSize)
 
-        // Show/hide: visível durante gravação/processamento OU se modo prompt ativo
-        let shouldShow = appState.state == .recording
+        // Show/hide: visível durante preparação/gravação/processamento OU se modo prompt ativo.
+        // Inclui `.preparing` para feedback imediato no press da hotkey (overlay
+        // aparece com spinner antes do engine capturar o 1º sample).
+        let shouldShow = appState.state == .preparing
+            || appState.state == .recording
             || appState.state == .processing
             || promptModeManager.isEnabled
 
@@ -152,7 +155,7 @@ struct ZSpeakApp: App {
         switch appState.state {
         case .idle:
             return "mic"
-        case .recording:
+        case .preparing, .recording:
             return "mic.fill"
         case .processing:
             return "waveform"

--- a/zspeak/AppState.swift
+++ b/zspeak/AppState.swift
@@ -14,8 +14,16 @@ final class AppState {
 
     enum RecordingState: Equatable {
         case idle          // Pronto para usar
-        case recording     // Gravando audio
+        case preparing     // Hotkey acionado; engine subindo, aguardando 1º sample
+        case recording     // Engine capturando áudio (1º sample já chegou)
         case processing    // Transcrevendo
+    }
+
+    /// Retorna true quando o usuário disparou a gravação e o pipeline está ativo,
+    /// independente de o engine já estar capturando samples ou ainda subindo.
+    /// Cobre `.preparing` e `.recording` — útil em guards que tratam ambos igual.
+    var isRecordingOrPreparing: Bool {
+        state == .preparing || state == .recording
     }
 
     var state: RecordingState = .idle
@@ -372,7 +380,7 @@ final class AppState {
         switch state {
         case .idle:
             startRecording()
-        case .recording:
+        case .preparing, .recording:
             stopRecording()
         case .processing:
             logger.info("toggleRecording: ignorado durante processing")
@@ -385,15 +393,17 @@ final class AppState {
         startRecording()
     }
 
-    /// Para gravação se estiver gravando — usado pelo modo Hold
+    /// Para gravação se estiver gravando OU preparando — usado pelo modo Hold
     func stopRecordingIfActive() {
-        guard state == .recording else { return }
+        guard isRecordingOrPreparing else { return }
         stopRecording()
     }
 
-    /// Cancela gravação em andamento — usado pelo Escape
+    /// Cancela gravação em andamento — usado pelo Escape.
+    /// Aceita tanto `.preparing` quanto `.recording`: se o usuário aperta ESC
+    /// durante o gap engine-subindo, ainda precisa limpar o pipeline.
     func cancelRecording() {
-        guard state == .recording else { return }
+        guard isRecordingOrPreparing else { return }
         state = .idle
         Task {
             await recordingTask?.value
@@ -420,10 +430,22 @@ final class AppState {
             return
         }
 
-        state = .recording
+        state = .preparing
         errorMessage = nil
         TextInserter.saveFocusedApp()
-        logger.info("startRecording: estado → recording")
+        logger.info("startRecording: estado → preparing")
+
+        // Callback @Sendable que faz hop para MainActor e promove preparing→recording.
+        // Só transiciona se ainda estiver em .preparing (caso o usuário tenha cancelado
+        // ou parado antes do 1º sample chegar, ignoramos).
+        let onFirstSample: @Sendable () -> Void = { [weak self] in
+            Task { @MainActor in
+                guard let self else { return }
+                guard self.state == .preparing else { return }
+                self.state = .recording
+                logger.info("startRecording: 1º sample chegou → estado → recording")
+            }
+        }
 
         recordingTask = Task {
             // Lista ordenada de candidatos. Vazia → usa apenas system default.
@@ -433,7 +455,7 @@ final class AppState {
                 logger.info("startRecording: candidatos vazios, usando system default")
                 microphoneManager.activeMicrophoneID = nil
                 do {
-                    try await audioCapture.start(deviceUID: nil)
+                    try await audioCapture.start(deviceUID: nil, onFirstSample: onFirstSample)
                     logger.info("startRecording: mic ativo = system default")
                 } catch {
                     logger.error("startRecording: system default falhou → \(String(describing: error), privacy: .public)")
@@ -453,7 +475,7 @@ final class AppState {
                 logger.info("startRecording: tentando mic \(mic.name, privacy: .public) (pos \(idx + 1)/\(candidatos.count))")
                 microphoneManager.activeMicrophoneID = mic.id
                 do {
-                    try await audioCapture.start(deviceUID: mic.id)
+                    try await audioCapture.start(deviceUID: mic.id, onFirstSample: onFirstSample)
                     logger.info("startRecording: mic \(mic.name, privacy: .public) OK")
                     logger.info("startRecording: mic ativo = \(mic.name, privacy: .public) (\(mic.id, privacy: .public))")
                     sucesso = true
@@ -470,7 +492,7 @@ final class AppState {
                 logger.info("startRecording: caindo para system default")
                 microphoneManager.activeMicrophoneID = nil
                 do {
-                    try await audioCapture.start(deviceUID: nil)
+                    try await audioCapture.start(deviceUID: nil, onFirstSample: onFirstSample)
                     logger.info("startRecording: mic ativo = system default")
                 } catch {
                     logger.error("startRecording: system default falhou → \(String(describing: error), privacy: .public)")

--- a/zspeak/AudioCapture.swift
+++ b/zspeak/AudioCapture.swift
@@ -91,11 +91,20 @@ actor AudioCapture {
     /// uniqueID do device usado no warmUp — se divergir do que `start()`
     /// recebe, descartamos o warm e reconfiguramos.
     private var warmedDeviceUID: String?
+    /// Callback invocado uma única vez quando o primeiro sample da sessão atual
+    /// chega no tap. Usado pelo AppState para transicionar do estado `.preparing`
+    /// (overlay com spinner) para `.recording` (overlay com waveform) apenas
+    /// quando o engine está de fato capturando áudio.
+    private var onFirstSampleCallback: (@Sendable () -> Void)?
 
     var isCapturing: Bool { isRunning }
 
-    /// Inicia captura do microfone, opcionalmente usando um device específico pelo uniqueID
-    func start(deviceUID: String? = nil) async throws {
+    /// Inicia captura do microfone, opcionalmente usando um device específico pelo uniqueID.
+    /// - Parameter onFirstSample: callback invocado uma única vez quando o primeiro
+    ///   buffer de áudio chega no tap. Permite ao chamador sincronizar UI com a
+    ///   transição HAL→engine→tap real, eliminando a janela em que o usuário vê
+    ///   "gravando" mas nenhuma amostra foi capturada ainda.
+    func start(deviceUID: String? = nil, onFirstSample: (@Sendable () -> Void)? = nil) async throws {
         let callTime = CFAbsoluteTimeGetCurrent()
 
         // Recria engine limpo (necessário após setInputDevice com device incompatível)
@@ -112,6 +121,7 @@ actor AudioCapture {
         startCalledTimestamp = callTime
         engineStartTimestamp = nil
         firstSampleTimestamp = nil
+        onFirstSampleCallback = onFirstSample
 
         let canFastPath = isWarmed && warmedDeviceUID == deviceUID
         isWarmed = false
@@ -225,8 +235,13 @@ actor AudioCapture {
 
     /// Instala o tap que alimenta `samplesBuffer` e atualiza `audioLevel`.
     /// Extraído para ser reutilizado por `configureAndStartEngine` e `warmUp`.
+    ///
+    /// bufferSize=512 (em vez do default 4096): a 48 kHz, o HAL acumula ~11 ms
+    /// de áudio antes do primeiro callback, contra ~85 ms com 4096. Corte direto
+    /// de ~74 ms na latência percebida até o primeiro sample chegar. Custo: mais
+    /// callbacks/s (~94 vs ~12), cada um ainda é barato (RMS + resample).
     private func installTap(on inputNode: AVAudioInputNode) {
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: nil) { [weak self] buffer, _ in
+        inputNode.installTap(onBus: 0, bufferSize: 512, format: nil) { [weak self] buffer, _ in
             guard let self else { return }
 
             let tapTime = CFAbsoluteTimeGetCurrent()
@@ -258,6 +273,7 @@ actor AudioCapture {
 
     /// Registra o timestamp do primeiro sample recebido após `engine.start()` e
     /// loga a latência. No-op depois do primeiro sample de cada sessão.
+    /// Invoca `onFirstSampleCallback` (fora do actor) para notificar o chamador.
     private func markFirstSampleIfNeeded(at timestamp: CFAbsoluteTime) {
         guard firstSampleTimestamp == nil else { return }
         firstSampleTimestamp = timestamp
@@ -265,6 +281,9 @@ actor AudioCapture {
             let delayMs = (timestamp - start) * 1000
             logger.info("markFirstSampleIfNeeded: primeiro sample após \(String(format: "%.1f", delayMs), privacy: .public)ms do engine.start()")
         }
+        let callback = onFirstSampleCallback
+        onFirstSampleCallback = nil
+        callback?()
     }
 
     /// Para a captura e retorna todas as amostras acumuladas

--- a/zspeak/Views/MenuBarView.swift
+++ b/zspeak/Views/MenuBarView.swift
@@ -65,7 +65,7 @@ struct MenuBarView: View {
         Divider()
 
         // Toggle de gravação
-        Button(appState.state == .recording ? "Parar Gravação" : "Iniciar Gravação") {
+        Button(appState.isRecordingOrPreparing ? "Parar Gravação" : "Iniciar Gravação") {
             appState.toggleRecording()
         }
         .keyboardShortcut("r", modifiers: [.command])
@@ -140,6 +140,7 @@ struct MenuBarView: View {
         case .idle:
             if appState.microphoneManager.permissionState != .authorized { return .orange }
             return appState.isModelReady ? .green : .gray
+        case .preparing: return .orange
         case .recording: return .red
         case .processing: return .yellow
         }
@@ -150,6 +151,7 @@ struct MenuBarView: View {
         if !appState.isModelReady { return "Carregando modelo..." }
         switch appState.state {
         case .idle: return "Pronto"
+        case .preparing: return "Preparando..."
         case .recording: return "Gravando..."
         case .processing: return "Transcrevendo..."
         }

--- a/zspeak/Views/OverlayView.swift
+++ b/zspeak/Views/OverlayView.swift
@@ -110,7 +110,20 @@ struct OverlayView: View {
             }
 
             // Bloco central por estado
-            if state == .recording {
+            if state == .preparing {
+                // Engine subindo entre o press do hotkey e o 1º sample real.
+                // Mostra um spinner discreto com o mesmo footprint vertical da
+                // waveform para evitar "pulo" de layout na transição → recording.
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                        .tint(.white.opacity(0.6))
+                    Text("Preparando microfone...")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.white.opacity(0.6))
+                }
+                .frame(height: 20)
+            } else if state == .recording {
                 WaveformView(model: model)
                     .frame(height: 20)
 


### PR DESCRIPTION
Closes #16

## Problema

Usuário relatava gap entre ver o overlay e o app começar a captar a fala: "começo a falar mas demora um pouco para começar a captar". Medição: overlay aparece imediato, mas engine leva ~170 ms (fast path warmed) + 85 ms (1º buffer com `bufferSize=4096` a 48 kHz) = **~255 ms no vazio** antes do 1º sample real chegar.

## Mudanças

### 1. `bufferSize: 4096 → 512` no tap
A 48 kHz: HAL acumula ~11 ms (vs ~85 ms) antes do 1º callback. Custo: mais callbacks/s, cada um ainda é barato (RMS + resample). Corte direto de ~74 ms na latência percebida.

### 2. Novo estado `.preparing`
`enum RecordingState` ganha case `.preparing` entre `.idle` e `.recording`. Overlay aparece no press do hotkey com spinner "Preparando microfone…" em vez de exibir waveform zerada durante o gap engine-subindo. Helper `isRecordingOrPreparing` para call sites que tratam ambos igual.

### 3. Transição `preparing → recording` via callback do 1º sample
`AudioCapture.start(deviceUID:onFirstSample:)` aceita closure `@Sendable`. `markFirstSampleIfNeeded` invoca o callback uma única vez quando o tap dispara a primeira amostra real. `AppState` promove `preparing → recording` no MainActor apenas aí, garantindo que o overlay só vire waveform quando está de fato capturando áudio.

## Arquivos alterados

- `zspeak/AudioCapture.swift` — bufferSize, parâmetro `onFirstSample`, invocação em `markFirstSampleIfNeeded`
- `zspeak/AppState.swift` — case `.preparing`, helper `isRecordingOrPreparing`, callback + transição
- `zspeak/App.swift` — `shouldShow` e `menuBarIcon` cobrem `.preparing`
- `zspeak/Views/OverlayView.swift` — ramo `.preparing` com ProgressView + texto
- `zspeak/Views/MenuBarView.swift` — `statusColor`/`statusText` exaustivos, label do botão usa helper
- `Tests/IntegrationTests.swift` — asserções imediatas pós-`toggleRecording` agora usam `isRecordingOrPreparing`; waits por saída de gravação também

## Validação

- Build Debug passou
- `scripts/install_app.sh` executado — DMG 52 MB gerado, app instalado em `/Applications/zspeak.app` e aberto para teste manual
- Telemetria existente (`markFirstSampleIfNeeded: primeiro sample após Xms`) segue ativa em `subsystem:com.zspeak` no Console.app para medir o ganho real antes/depois

## Notas para o review

- Não testamos a mudança (2) isolada da (3): juntas elas cobrem UX + modelagem correta. Separá-las exigiria flag booleana adicional e manteria estado mentindo sobre a captura durante o gap.
- `.preparing` é tratado como "cancelável" — ESC/toggle/stop durante esse estado também limpam o pipeline.
- Testes continuam hardware-dependent (mic real necessário) no fallback de system default; comportamento CI inalterado (skip via `ProcessInfo.environment["CI"]`).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
