### PR TITLE
fix(audio): trava intermitente em Preparando microfone

### DIFF
--- a/zspeak/AudioCapture.swift
+++ b/zspeak/AudioCapture.swift
@@ -47,6 +47,18 @@ final class AtomicInt: @unchecked Sendable {
         os_unfair_lock_unlock(&lock)
     }
 
+    /// Tenta transicionar de 0 → 1 atômico. Retorna `true` se foi quem setou;
+    /// `false` se já estava em 1 (ou qualquer outro valor). Usado como latch
+    /// "rode isso apenas uma vez" no hotpath do tap, evitando enfileirar
+    /// Tasks repetidas no actor a cada buffer (~94 Hz).
+    func setIfZero() -> Bool {
+        os_unfair_lock_lock(&lock)
+        defer { os_unfair_lock_unlock(&lock) }
+        guard value == 0 else { return false }
+        value = 1
+        return true
+    }
+
     var current: Int {
         os_unfair_lock_lock(&lock)
         defer { os_unfair_lock_unlock(&lock) }
@@ -153,6 +165,10 @@ actor AudioCapture {
     nonisolated(unsafe) private let converter = AudioConverter()
     /// Contador atômico de erros de resample — incrementado no tap.
     private let resampleErrors = AtomicInt()
+    /// Latch atômico usado pelo tap para agendar UMA única `Task` no actor
+    /// quando o primeiro sample chega. Sem isso, o tap (~94 Hz) enfileirava
+    /// uma Task a cada callback durante toda a gravação. Resetado em `start()`.
+    private let firstSampleScheduled = AtomicInt()
     /// Monitor thread-safe de nível de áudio. Compartilhado entre actor (start/stop)
     /// e tap (render thread). Exposto para leitura sincrona via `currentAudioLevel()`.
     nonisolated let audioLevelMonitor = AudioLevelMonitor()
@@ -216,6 +232,7 @@ actor AudioCapture {
         samplesBuffer.clear()
         samplesBuffer.reserveCapacity(Self.expectedMaxCaptureDurationSeconds * Self.targetSampleRate)
         resampleErrors.reset()
+        firstSampleScheduled.reset()
         currentDeviceUID = deviceUID
         audioLevelMonitor.reset()
         startCalledTimestamp = callTime
@@ -352,6 +369,7 @@ actor AudioCapture {
         let levelMonitor = audioLevelMonitor
         let converter = self.converter
         let errors = resampleErrors
+        let firstSampleLatch = firstSampleScheduled
 
         inputNode.installTap(onBus: 0, bufferSize: 512, format: nil) { [weak self] avBuffer, _ in
             let tapTime = CFAbsoluteTimeGetCurrent()
@@ -379,10 +397,13 @@ actor AudioCapture {
                 errors.increment()
             }
 
-            // Hop único para o actor APENAS no primeiro sample — a lógica de
-            // `firstSampleTimestamp` e do callback precisa rodar isolada no actor.
-            // Depois disso, `self?` vira no-op porque o actor checa e retorna cedo.
-            if let self {
+            // Hop único para o actor APENAS no primeiro sample. O latch atômico
+            // garante que só UMA Task seja enfileirada por sessão, mesmo que o
+            // tap rode ~94 vezes/s. Sem esse latch, cada callback criava uma
+            // Task nova que só virava no-op DENTRO do actor — gerando pressão
+            // de scheduler que podia atrasar a invocação de onFirstSample e
+            // deixar o app preso em "Preparando microfone...".
+            if firstSampleLatch.setIfZero(), let self {
                 Task { [weak self] in
                     await self?.markFirstSampleIfNeeded(at: tapTime)
                 }
@@ -460,6 +481,19 @@ actor AudioCapture {
     /// amostras vazias como "áudio curto" e volta para idle.
     private func handleConfigurationChange() {
         guard isRunning else { return }
+
+        // Ignorar mudanças ocorridas durante estabilização do engine (antes do
+        // primeiro sample chegar no tap). Nesse intervalo o HAL ainda está
+        // negociando formato com o device recém-selecionado e dispara
+        // `AVAudioEngineConfigurationChange` como parte do setup normal.
+        // Parar o engine aqui deixa o app preso em "Preparando microfone..."
+        // porque o tap nunca chega a receber o primeiro buffer. Regressão
+        // intermitente introduzida na Onda 1 (reinstalação do observer em
+        // warmUp expôs mais esses callbacks benignos).
+        guard firstSampleTimestamp != nil else {
+            logger.debug("handleConfigurationChange: ignorado (pré-primeiro-sample, HAL estabilizando)")
+            return
+        }
 
         engine.stop()
         engine.inputNode.removeTap(onBus: 0)


### PR DESCRIPTION
## Sumário

Fix de regressão intermitente introduzida na Onda 1 (#29): "Preparando microfone..." travava sem voltar pra idle nem pra recording.

## Sintoma relatado pelo usuário

Overlay aparece em estado "Preparando microfone..." e não avança. Às vezes funciona, às vezes não — depende de timing do HAL.

## Causa raiz

Dois bugs combinados:

### 1. Observer de ConfigurationChange parando engine benigno

O `AVAudioEngine` dispara `AVAudioEngineConfigurationChange` como parte normal da estabilização quando troca de input device. Na Onda 1 o observer passou a ser reinstalado também em `warmUp`, aumentando a janela em que esses callbacks chegam — e `handleConfigurationChange` parava o engine (`engine.stop()` + `removeTap`) sem saber que era transitório.

Como o tap nunca chegava a receber o primeiro buffer, `onFirstSample` nunca disparava, e o `RecordingController` ficava em `.preparing` indefinidamente.

### 2. Task/s no hotpath contribuindo pra race

A "otimização" anunciada na Onda 1 ("Task única por sessão") não foi realmente aplicada: o tap ainda enfileirava uma Task por callback (~94 Hz), e só o guard dentro do actor era no-op. Sob pressão de scheduler, a primeira Task atrasava, alongando a janela do bug 1.

## Fix

1. `handleConfigurationChange` retorna cedo se `firstSampleTimestamp == nil`. Depois que o tap entregou o primeiro sample, config change é tratada normalmente.
2. Novo `AtomicInt.setIfZero()` usado como latch no tap. Agenda **uma única** Task por sessão. Resetado em `start()`.

## Plano de testes manuais

- [ ] Hotkey de gravação 10 vezes seguidas — nenhuma trava no "Preparando microfone..."
- [ ] Gravação normal (5s-60s) — transcreve e cola corretamente
- [ ] ESC durante gravação — cancela
- [ ] Trocar microfone em System Settings enquanto grava — app continua ou para com erro legível, nunca trava

🤖 Generated with [Claude Code](https://claude.com/claude-code)
