### PR TITLE
feat(settings): overhaul completo — consolidação + IA + polimento por página

### DIFF
--- a/zspeak/App.swift
+++ b/zspeak/App.swift
@@ -135,19 +135,46 @@ struct ZSpeakApp: App {
     nonisolated(unsafe) private static var overlayController: OverlayController?
 
     var body: some Scene {
-        // App vive exclusivamente no menu bar (sem janela principal)
+        // App vive exclusivamente no menu bar (sem janela principal).
+        // Dependências são injetadas via `.environment(_:)` — SwiftUI 5 aceita
+        // classes `@Observable` diretamente, sem precisar de `@EnvironmentObject`.
         MenuBarExtra {
-            MenuBarView(appState: appState, activationKeyManager: activationKeyManager, accessibilityManager: accessibilityManager, store: store, benchmarkStore: benchmarkStore, vocabularyStore: vocabularyStore, correctionPromptStore: correctionPromptStore, promptModeManager: promptModeManager)
+            MenuBarView()
+                .environment(appState)
+                .environment(appState.microphoneManager)
+                .environment(activationKeyManager)
+                .environment(accessibilityManager)
+                .environment(store)
+                .environment(benchmarkStore)
+                .environment(vocabularyStore)
+                .environment(correctionPromptStore)
+                .environment(promptModeManager)
         } label: {
             Image(systemName: menuBarIcon)
                 .symbolRenderingMode(.palette)
         }
 
-        // Janela de configurações
+        // Janela de configurações — init sem parâmetros; consome `@Environment`.
         Settings {
-            let mgr = appState.microphoneManager
-            SettingsView(appState: appState, microphoneManager: mgr, activationKeyManager: activationKeyManager, accessibilityManager: accessibilityManager, store: store, benchmarkStore: benchmarkStore, vocabularyStore: vocabularyStore, correctionPromptStore: correctionPromptStore)
+            SettingsView()
+                .environment(appState)
+                .environment(appState.microphoneManager)
+                .environment(activationKeyManager)
+                .environment(accessibilityManager)
+                .environment(store)
+                .environment(benchmarkStore)
+                .environment(vocabularyStore)
+                .environment(correctionPromptStore)
+                .environment(promptModeManager)
         }
+
+        // Janela dedicada para transcrever arquivo de áudio (Cmd+Shift+T).
+        Window("Transcrever arquivo", id: AudioFileWindowID.value) {
+            AudioFileWindowContent()
+                .environment(appState)
+                .environment(store)
+        }
+        .defaultSize(width: 720, height: 580)
     }
 
     /// Ícone do menu bar baseado no estado atual

--- a/zspeak/ErrorMapper.swift
+++ b/zspeak/ErrorMapper.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Traduz erros técnicos (OSStatus, domínios opacos) para mensagens que o
+/// usuário final consegue agir. Centralizar aqui evita espalhar `switch`s de
+/// códigos de erro nas Views.
+enum ErrorMapper {
+    static func friendlyMessage(for error: Error) -> String {
+        let ns = error as NSError
+        // OSStatus conhecidos
+        if ns.domain == NSOSStatusErrorDomain {
+            switch ns.code {
+            case -10868: return "Formato de áudio incompatível com o microfone selecionado. Tente trocar de dispositivo."
+            case -10851: return "Propriedade de áudio inválida."
+            case -10877: return "Dispositivo de áudio indisponível."
+            case -10875: return "Dispositivo de áudio ocupado por outro app."
+            case -10863: return "Hardware não suportado."
+            case -50: return "Parâmetro inválido."
+            case -66681: return "Falha ao iniciar o motor de áudio."
+            default: break
+            }
+        }
+        if let localized = error as? LocalizedError, let desc = localized.errorDescription { return desc }
+        return "Erro inesperado (código \(ns.code))"
+    }
+}

--- a/zspeak/Views/AudioFileWindow.swift
+++ b/zspeak/Views/AudioFileWindow.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+/// Identificador da Window Scene de transcrição de arquivo — mantido em
+/// constante para não divergir entre App.swift (declaração) e MenuBarView
+/// (openWindow(id:)).
+enum AudioFileWindowID {
+    static let value: String = "audio-file"
+}
+
+/// Conteúdo da janela flutuante de transcrição de arquivo.
+///
+/// Lê dependências via `@Environment` (AppState, TranscriptionStore) e encaminha
+/// para `AudioFileView`, que já existe e é reutilizada sem modificações.
+struct AudioFileWindowContent: View {
+    @Environment(AppState.self) private var appState
+    @Environment(TranscriptionStore.self) private var store
+
+    var body: some View {
+        AudioFileView(appState: appState, store: store)
+            .frame(minWidth: 640, minHeight: 520)
+            .navigationTitle("Transcrever arquivo")
+    }
+}

--- a/zspeak/Views/BenchmarkView.swift
+++ b/zspeak/Views/BenchmarkView.swift
@@ -17,6 +17,55 @@ struct BenchmarkView: View {
     /// Cache de arquivos de áudio existentes — computado uma vez por render, evita `fileExists` por linha.
     @State private var availableAudioFiles: Set<String> = []
 
+    // MARK: - Estado de execução em lote
+    @State private var runAllTask: Task<Void, Never>?
+    @State private var runAllProgress: Double = 0
+    @State private var runAllCurrent: Int = 0
+    @State private var runAllTotal: Int = 0
+
+    // MARK: - Erros por fixture
+    @State private var errorsById: [UUID: String] = [:]
+
+    // MARK: - Filtros
+    @State private var showOnlyHighError = false
+
+    /// Fixtures visíveis após aplicar filtro de alto erro (> 10% WER).
+    private var visibleFixtures: [(offset: Int, element: BenchmarkFixture)] {
+        let all = Array(store.fixtures.enumerated())
+        guard showOnlyHighError else { return all.map { ($0.offset, $0.element) } }
+        return all
+            .filter { _, fixture in
+                guard let result = fixture.lastResult else { return false }
+                let errorRate = result.wordErrorRate ?? (1 - result.accuracyScore)
+                return errorRate > 0.1
+            }
+            .map { ($0.offset, $0.element) }
+    }
+
+    /// Métricas agregadas sobre fixtures com `lastResult` não-nil.
+    private var aggregateMetrics: AggregateMetrics? {
+        let evaluated = store.fixtures.compactMap { $0.lastResult }
+        guard !evaluated.isEmpty else { return nil }
+
+        let avgAcc = evaluated.map(\.accuracyScore).reduce(0, +) / Double(evaluated.count)
+
+        let wers = evaluated.compactMap(\.wordErrorRate)
+        let avgWer = wers.isEmpty ? nil : wers.reduce(0, +) / Double(wers.count)
+
+        let cers = evaluated.compactMap(\.characterErrorRate)
+        let avgCer = cers.isEmpty ? nil : cers.reduce(0, +) / Double(cers.count)
+
+        let avgLatency = evaluated.map(\.latency).reduce(0, +) / Double(evaluated.count)
+
+        return AggregateMetrics(
+            count: evaluated.count,
+            averageAccuracy: avgAcc,
+            averageWER: avgWer,
+            averageCER: avgCer,
+            averageLatency: avgLatency
+        )
+    }
+
     var body: some View {
         Form {
             if isLoadingFixtures {
@@ -26,15 +75,63 @@ struct BenchmarkView: View {
                     ProgressView()
                 }
             } else if store.fixtures.isEmpty {
-                ContentUnavailableView(
-                    "Nenhuma fixture",
-                    systemImage: "gauge.with.needle",
-                    description: Text("Importe WAVs ou use transcrições do histórico para criar fixtures de benchmark.")
-                )
+                ContentUnavailableView {
+                    Label("Nenhuma fixture", systemImage: "gauge.with.needle")
+                } description: {
+                    Text("Importe WAVs ou use transcrições do histórico para criar fixtures de benchmark.")
+                } actions: {
+                    Menu {
+                        Button {
+                            importWAV()
+                        } label: {
+                            Label("Importar WAV…", systemImage: "square.and.arrow.down")
+                        }
+                        Button {
+                            store.importFromHistory(historyStore: historyStore)
+                        } label: {
+                            Label("Importar do Histórico", systemImage: "clock.arrow.circlepath")
+                        }
+                    } label: {
+                        Label("Adicionar fixture", systemImage: "plus.circle.fill")
+                    }
+                    .menuStyle(.borderedButton)
+                    .controlSize(.large)
+                }
             } else {
-                ForEach(Array(store.fixtures.enumerated()), id: \.element.id) { index, fixture in
+                // Card agregado no topo — só aparece se há resultados
+                if let metrics = aggregateMetrics {
                     Section {
-                        fixtureRow(fixture, index: index)
+                        aggregateCard(metrics)
+                    }
+                }
+
+                // Progresso global quando rodando "Transcrever Todos"
+                if isRunning && runAllTotal > 0 {
+                    Section {
+                        runAllProgressView
+                    }
+                }
+
+                // Filtro
+                if aggregateMetrics != nil {
+                    Section {
+                        Toggle("Mostrar só fixtures com erro > 10%", isOn: $showOnlyHighError)
+                    }
+                }
+
+                if visibleFixtures.isEmpty {
+                    Section {
+                        ContentUnavailableView(
+                            "Nenhuma fixture com erro alto",
+                            systemImage: "checkmark.seal.fill",
+                            description: Text("Todas as fixtures avaliadas têm WER ≤ 10%.")
+                        )
+                    }
+                } else {
+                    ForEach(visibleFixtures, id: \.element.id) { index, fixture in
+                        Section {
+                            fixtureRow(fixture, index: index)
+                        }
                     }
                 }
             }
@@ -49,29 +146,45 @@ struct BenchmarkView: View {
         .onChange(of: store.fixtures.count) {
             availableAudioFiles = store.availableAudioFileNames()
         }
-        .onDisappear { stopAudio() }
+        .onDisappear {
+            stopAudio()
+            runAllTask?.cancel()
+        }
         .toolbar {
             ToolbarItemGroup {
-                Button {
-                    importWAV()
+                // Ações secundárias agrupadas em Menu "+ Adicionar"
+                Menu {
+                    Button {
+                        importWAV()
+                    } label: {
+                        Label("Importar WAV…", systemImage: "square.and.arrow.down")
+                    }
+                    Button {
+                        store.importFromHistory(historyStore: historyStore)
+                    } label: {
+                        Label("Importar do Histórico", systemImage: "clock.arrow.circlepath")
+                    }
                 } label: {
-                    Label("Importar WAV", systemImage: "square.and.arrow.down")
+                    Label("Adicionar", systemImage: "plus")
                 }
                 .disabled(isRunning)
 
+                // Ação primária isolada: Transcrever Todos / Parar
                 Button {
-                    store.importFromHistory(historyStore: historyStore)
+                    if isRunning {
+                        runAllTask?.cancel()
+                    } else {
+                        runAll()
+                    }
                 } label: {
-                    Label("Importar do Histórico", systemImage: "clock.arrow.circlepath")
+                    if isRunning {
+                        Label("Parar", systemImage: "stop.fill")
+                    } else {
+                        Label("Transcrever Todos", systemImage: "play.fill")
+                    }
                 }
-                .disabled(isRunning)
-
-                Button {
-                    runAll()
-                } label: {
-                    Label("Transcrever Todos", systemImage: "play.fill")
-                }
-                .disabled(isRunning || store.fixtures.isEmpty)
+                .keyboardShortcut(isRunning ? .cancelAction : .defaultAction)
+                .disabled(!isRunning && store.fixtures.isEmpty)
             }
         }
         .alert("Apagar fixture?", isPresented: .init(
@@ -82,11 +195,104 @@ struct BenchmarkView: View {
             Button("Apagar", role: .destructive) {
                 if let fixture = fixtureToDelete {
                     store.deleteFixture(fixture)
+                    errorsById.removeValue(forKey: fixture.id)
                     fixtureToDelete = nil
                 }
             }
         } message: {
             Text("Esta ação não pode ser desfeita.")
+        }
+    }
+
+    // MARK: - Card agregado
+
+    private struct AggregateMetrics {
+        let count: Int
+        let averageAccuracy: Double
+        let averageWER: Double?
+        let averageCER: Double?
+        let averageLatency: TimeInterval
+    }
+
+    @ViewBuilder
+    private func aggregateCard(_ metrics: AggregateMetrics) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Label("Resumo agregado", systemImage: "chart.bar.doc.horizontal")
+                    .font(.headline)
+                Spacer()
+                Text("\(metrics.count) \(metrics.count == 1 ? "fixture avaliada" : "fixtures avaliadas")")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack(spacing: 16) {
+                metricCard(
+                    title: "Acurácia média",
+                    value: String(format: "%.0f%%", metrics.averageAccuracy * 100),
+                    icon: "checkmark.seal.fill",
+                    color: accuracyColor(metrics.averageAccuracy)
+                )
+
+                if let wer = metrics.averageWER {
+                    metricCard(
+                        title: "WER médio",
+                        value: String(format: "%.1f%%", wer * 100),
+                        icon: "textformat.abc",
+                        color: errorRateColor(wer)
+                    )
+                }
+
+                if let cer = metrics.averageCER {
+                    metricCard(
+                        title: "CER médio",
+                        value: String(format: "%.1f%%", cer * 100),
+                        icon: "character.cursor.ibeam",
+                        color: errorRateColor(cer)
+                    )
+                }
+
+                metricCard(
+                    title: "Latência média",
+                    value: String(format: "%.0fms", metrics.averageLatency * 1000),
+                    icon: "timer",
+                    color: .secondary
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func metricCard(title: String, value: String, icon: String, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Label(title, systemImage: icon)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(color)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Progresso global
+
+    @ViewBuilder
+    private var runAllProgressView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Label(
+                    "Transcrevendo fixture \(runAllCurrent) de \(runAllTotal)",
+                    systemImage: "waveform.badge.magnifyingglass"
+                )
+                .font(.subheadline.weight(.medium))
+                Spacer()
+                Text(String(format: "%.0f%%", runAllProgress * 100))
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            ProgressView(value: runAllProgress)
+                .progressViewStyle(.linear)
         }
     }
 
@@ -117,6 +323,23 @@ struct BenchmarkView: View {
         // Último resultado
         if let result = fixture.lastResult {
             resultSection(result)
+        }
+
+        // Mensagem de erro (se runBenchmark falhou)
+        if let errorMessage = errorsById[fixture.id] {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.red)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Erro ao transcrever")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.red)
+                    Text(errorMessage)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+            }
         }
 
         // Ações
@@ -220,8 +443,13 @@ struct BenchmarkView: View {
         Task {
             isRunning = true
             runningFixtureId = fixture.id
-            try? await store.runBenchmark(fixture: fixture) { samples in
-                try await appState.transcribe(samples)
+            errorsById.removeValue(forKey: fixture.id)
+            do {
+                try await store.runBenchmark(fixture: fixture) { samples in
+                    try await appState.transcribe(samples)
+                }
+            } catch {
+                errorsById[fixture.id] = error.localizedDescription
             }
             runningFixtureId = nil
             isRunning = false
@@ -229,12 +457,43 @@ struct BenchmarkView: View {
     }
 
     private func runAll() {
-        Task {
+        let fixturesSnapshot = store.fixtures
+        guard !fixturesSnapshot.isEmpty else { return }
+
+        runAllCurrent = 0
+        runAllTotal = fixturesSnapshot.count
+        runAllProgress = 0
+
+        runAllTask = Task {
             isRunning = true
-            await store.runAll { samples in
-                try await appState.transcribe(samples)
+            defer {
+                isRunning = false
+                runningFixtureId = nil
+                runAllTask = nil
             }
-            isRunning = false
+
+            for (idx, fixture) in fixturesSnapshot.enumerated() {
+                if Task.isCancelled { break }
+
+                runAllCurrent = idx + 1
+                runAllProgress = Double(idx) / Double(fixturesSnapshot.count)
+                runningFixtureId = fixture.id
+                errorsById.removeValue(forKey: fixture.id)
+
+                do {
+                    try await store.runBenchmark(fixture: fixture) { samples in
+                        try await appState.transcribe(samples)
+                    }
+                } catch is CancellationError {
+                    break
+                } catch {
+                    errorsById[fixture.id] = error.localizedDescription
+                }
+            }
+
+            if !Task.isCancelled {
+                runAllProgress = 1
+            }
         }
     }
 

--- a/zspeak/Views/CorrectionPromptsView.swift
+++ b/zspeak/Views/CorrectionPromptsView.swift
@@ -1,13 +1,27 @@
 import SwiftUI
 
-/// Tela de gerenciamento de prompts de correção LLM
+/// Tela de gerenciamento de prompts de correção LLM.
+///
+/// Layout:
+/// - Toggle global "Correção LLM ativa"
+/// - Seção "Modelo LLM" compacta: um único HStack com ícone + título + badge + CTA único
+///   (Baixar / Carregar / Remover). Durante download, progresso determinado.
+/// - Lista de prompts como `DisclosureGroup` colapsado por default; header mostra nome
+///   + badge "Ativo" se ativo. Expandido exibe nome, prompt sistema, radio de ativação e apagar.
+/// - Toolbar com "+" (prompt em branco) e menu de templates
+/// - Autosave com debounce de 500ms
 struct CorrectionPromptsView: View {
     let appState: AppState
     @Bindable var store: CorrectionPromptStore
 
     @State private var promptToDelete: CorrectionPrompt?
     @State private var modelState: LLMCorrectionManager.ModelState = .notDownloaded
-    @State private var isDownloading = false
+    @State private var isBusy = false
+    @State private var expandedIDs: Set<UUID> = []
+
+    @State private var autosaveToken: Int = 0
+
+    // MARK: - Body
 
     var body: some View {
         Form {
@@ -16,107 +30,39 @@ struct CorrectionPromptsView: View {
                 Toggle("Correção LLM ativa", isOn: Bindable(appState).llmCorrectionEnabled)
             }
 
-            // Seção modelo LLM
+            // Modelo LLM compacto
             Section("Modelo LLM") {
-                HStack {
-                    Label {
-                        switch modelState {
-                        case .notDownloaded:
-                            Text("Modelo não baixado")
-                        case .downloading(let progress):
-                            Text("Baixando... \(Int(progress * 100))%")
-                        case .downloaded:
-                            Text("Modelo baixado")
-                        case .loading:
-                            Text("Carregando modelo...")
-                        case .ready:
-                            Text("Modelo pronto")
-                        case .error(let message):
-                            Text("Erro: \(message)")
-                                .foregroundStyle(.red)
-                        }
-                    } icon: {
-                        Image(systemName: modelStateIcon)
-                            .foregroundStyle(modelStateColor)
-                    }
-
-                    Spacer()
-
-                    if isDownloading {
-                        ProgressView()
-                            .controlSize(.small)
-                    }
+                modelRow
+                if case .downloading(let progress) = modelState {
+                    ProgressView(value: progress, total: 1.0)
+                        .progressViewStyle(.linear)
                 }
-
-                switch modelState {
-                case .notDownloaded, .error:
-                    Button("Baixar Modelo") {
-                        downloadModel()
-                    }
-                    .disabled(isDownloading)
-                    .accessibilityIdentifier("downloadModelButton")
-
-                case .downloaded:
-                    Button("Carregar Modelo") {
-                        loadModel()
-                    }
-                    .accessibilityIdentifier("loadModelButton")
-                    Button("Remover Modelo", role: .destructive) {
-                        removeModel()
-                    }
-                    .accessibilityIdentifier("removeModelButton")
-
-                case .ready:
-                    Text("Modelo pronto para uso")
-                        .foregroundStyle(.green)
-                    Button("Remover Modelo", role: .destructive) {
-                        removeModel()
-                    }
-
-                default:
-                    EmptyView()
+                if case .error(let message) = modelState {
+                    Text(message)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .textSelection(.enabled)
                 }
             }
 
-            // Seção prompts
+            // Lista de prompts
             Section("Prompts") {
                 if store.prompts.isEmpty {
-                    ContentUnavailableView(
-                        "Nenhum prompt",
-                        systemImage: "sparkles",
-                        description: Text("Adicione prompts para correção pós-transcrição.")
-                    )
-                } else {
-                    ForEach(Array(store.prompts.enumerated()), id: \.element.id) { index, prompt in
-                        Section {
-                            TextField("Nome", text: $store.prompts[index].name)
-
-                            TextEditor(text: $store.prompts[index].systemPrompt)
-                                .frame(minHeight: 60, maxHeight: 100)
-                                .font(.body)
-
-                            HStack {
-                                Button {
-                                    store.setActive(prompt)
-                                } label: {
-                                    Label(
-                                        prompt.isActive ? "Ativo" : "Ativar",
-                                        systemImage: prompt.isActive
-                                            ? "checkmark.circle.fill"
-                                            : "circle"
-                                    )
-                                    .foregroundStyle(prompt.isActive ? .green : .secondary)
-                                }
-                                .buttonStyle(.borderless)
-
-                                Spacer()
-
-                                Button("Apagar", role: .destructive) {
-                                    promptToDelete = prompt
-                                }
-                                .buttonStyle(.borderless)
-                            }
+                    ContentUnavailableView {
+                        Label("Nenhum prompt", systemImage: "sparkles")
+                    } description: {
+                        Text("Adicione prompts para correção pós-transcrição ou use um template.")
+                    } actions: {
+                        Menu {
+                            templateMenuItems
+                        } label: {
+                            Label("Usar template", systemImage: "wand.and.stars")
                         }
+                        .menuStyle(.borderlessButton)
+                    }
+                } else {
+                    ForEach(store.prompts.indices, id: \.self) { index in
+                        promptRow(at: index)
                     }
                 }
             }
@@ -125,8 +71,14 @@ struct CorrectionPromptsView: View {
         .navigationTitle("Correção LLM")
         .toolbar {
             ToolbarItemGroup {
+                Menu {
+                    templateMenuItems
+                } label: {
+                    Label("Template", systemImage: "wand.and.stars")
+                }
+
                 Button {
-                    store.addPrompt(name: "Novo prompt", systemPrompt: "")
+                    addBlankPrompt()
                 } label: {
                     Label("Adicionar Prompt", systemImage: "plus")
                 }
@@ -140,6 +92,7 @@ struct CorrectionPromptsView: View {
             Button("Apagar", role: .destructive) {
                 if let prompt = promptToDelete {
                     store.deletePrompt(prompt)
+                    expandedIDs.remove(prompt.id)
                     promptToDelete = nil
                 }
             }
@@ -147,6 +100,12 @@ struct CorrectionPromptsView: View {
             Text("Esta ação não pode ser desfeita.")
         }
         .onChange(of: store.prompts) {
+            autosaveToken &+= 1
+        }
+        .task(id: autosaveToken) {
+            guard autosaveToken > 0 else { return }
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            guard !Task.isCancelled else { return }
             store.save()
         }
         .task {
@@ -154,7 +113,81 @@ struct CorrectionPromptsView: View {
         }
     }
 
-    // MARK: - Modelo
+    // MARK: - Model row
+
+    @ViewBuilder
+    private var modelRow: some View {
+        HStack(spacing: 10) {
+            Image(systemName: modelStateIcon)
+                .foregroundStyle(modelStateColor)
+                .font(.title3)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Qwen 2.5 3B")
+                    .font(.body)
+                Text(modelStateSubtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            modelStateBadge
+
+            modelCTA
+        }
+    }
+
+    @ViewBuilder
+    private var modelStateBadge: some View {
+        Text(modelStateBadgeText)
+            .font(.caption2.weight(.medium))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+                Capsule().fill(modelStateColor.opacity(0.2))
+            )
+            .foregroundStyle(modelStateColor)
+    }
+
+    @ViewBuilder
+    private var modelCTA: some View {
+        switch modelState {
+        case .notDownloaded, .error:
+            Button("Baixar") { downloadModel() }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .disabled(isBusy)
+                .accessibilityIdentifier("downloadModelButton")
+
+        case .downloading:
+            ProgressView()
+                .controlSize(.small)
+
+        case .downloaded:
+            HStack(spacing: 6) {
+                Button("Carregar") { loadModel() }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .accessibilityIdentifier("loadModelButton")
+                Button("Remover", role: .destructive) { removeModel() }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .accessibilityIdentifier("removeModelButton")
+            }
+
+        case .loading:
+            ProgressView()
+                .controlSize(.small)
+
+        case .ready:
+            Button("Remover", role: .destructive) { removeModel() }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .accessibilityIdentifier("removeModelButton")
+        }
+    }
 
     private var modelStateIcon: String {
         switch modelState {
@@ -178,26 +211,186 @@ struct CorrectionPromptsView: View {
         }
     }
 
+    private var modelStateBadgeText: String {
+        switch modelState {
+        case .notDownloaded: "Não baixado"
+        case .downloading(let progress): "Baixando \(Int(progress * 100))%"
+        case .loading: "Carregando"
+        case .downloaded: "Baixado"
+        case .ready: "Pronto"
+        case .error: "Erro"
+        }
+    }
+
+    private var modelStateSubtitle: String {
+        switch modelState {
+        case .notDownloaded: "Modelo LLM para correção pós-transcrição"
+        case .downloading: "Baixando pesos do HuggingFace…"
+        case .loading: "Carregando na memória…"
+        case .downloaded: "Pronto para carregar"
+        case .ready: "Pronto para corrigir transcrições"
+        case .error: "Falha — tente novamente"
+        }
+    }
+
+    // MARK: - Prompt row
+
+    @ViewBuilder
+    private func promptRow(at index: Int) -> some View {
+        let prompt = store.prompts[index]
+        let isExpanded = Binding<Bool>(
+            get: { expandedIDs.contains(prompt.id) },
+            set: { newValue in
+                if newValue { expandedIDs.insert(prompt.id) }
+                else { expandedIDs.remove(prompt.id) }
+            }
+        )
+
+        DisclosureGroup(isExpanded: isExpanded) {
+            VStack(alignment: .leading, spacing: 10) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Nome")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextField("Nome", text: $store.prompts[index].name)
+                        .textFieldStyle(.roundedBorder)
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Instrução do sistema")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    TextEditor(text: $store.prompts[index].systemPrompt)
+                        .frame(minHeight: 60, maxHeight: 100)
+                        .font(.body)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 6)
+                                .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                        )
+                }
+
+                HStack {
+                    Button {
+                        store.setActive(prompt)
+                    } label: {
+                        Label(
+                            prompt.isActive ? "Ativo" : "Definir como ativo",
+                            systemImage: prompt.isActive ? "circle.fill" : "circle"
+                        )
+                        .foregroundStyle(prompt.isActive ? .green : .secondary)
+                    }
+                    .buttonStyle(.borderless)
+
+                    Spacer()
+
+                    Button(role: .destructive) {
+                        promptToDelete = prompt
+                    } label: {
+                        Label("Apagar", systemImage: "trash")
+                    }
+                    .buttonStyle(.borderless)
+                    .foregroundStyle(.red)
+                }
+            }
+            .padding(.vertical, 4)
+        } label: {
+            HStack(spacing: 8) {
+                Text(prompt.name.isEmpty ? "(sem nome)" : prompt.name)
+                    .font(.body)
+                    .foregroundStyle(prompt.name.isEmpty ? .secondary : .primary)
+                    .lineLimit(1)
+                Spacer()
+                if prompt.isActive {
+                    Text("Ativo")
+                        .font(.caption2.weight(.medium))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Capsule().fill(Color.green.opacity(0.2)))
+                        .foregroundStyle(.green)
+                }
+            }
+        }
+    }
+
+    // MARK: - Templates
+
+    @ViewBuilder
+    private var templateMenuItems: some View {
+        ForEach(CorrectionPromptTemplate.all) { template in
+            Button(template.name) {
+                addFromTemplate(template)
+            }
+        }
+    }
+
+    private func addBlankPrompt() {
+        store.addPrompt(name: "Novo prompt", systemPrompt: "")
+        if let newID = store.prompts.last?.id {
+            expandedIDs.insert(newID)
+        }
+    }
+
+    private func addFromTemplate(_ template: CorrectionPromptTemplate) {
+        store.addPrompt(name: template.name, systemPrompt: template.systemPrompt)
+        if let newID = store.prompts.last?.id {
+            expandedIDs.insert(newID)
+        }
+    }
+
+    // MARK: - Modelo
+
     private func downloadModel() {
         Task {
-            isDownloading = true
+            isBusy = true
             modelState = .downloading(progress: 0)
             modelState = await appState.downloadLLMModel()
-            isDownloading = false
+            isBusy = false
         }
     }
 
     private func loadModel() {
         Task {
+            isBusy = true
             modelState = .loading
             modelState = await appState.loadLLMModel()
+            isBusy = false
         }
     }
 
     private func removeModel() {
         Task {
+            isBusy = true
             await appState.removeLLMModel()
             modelState = .notDownloaded
+            isBusy = false
         }
     }
+}
+
+// MARK: - Templates
+
+/// Templates de prompts pré-definidos oferecidos no menu do toolbar.
+private struct CorrectionPromptTemplate: Identifiable {
+    let id = UUID()
+    let name: String
+    let systemPrompt: String
+
+    static let all: [CorrectionPromptTemplate] = [
+        CorrectionPromptTemplate(
+            name: "Correção geral",
+            systemPrompt: "Corrija ortografia, pontuação e capitalização do texto transcrito. Mantenha o significado original e termos técnicos em inglês. Retorne apenas o texto corrigido, sem explicações."
+        ),
+        CorrectionPromptTemplate(
+            name: "Formalizar",
+            systemPrompt: "Reescreva o texto transcrito em tom mais formal e profissional. Mantenha termos técnicos em inglês. Retorne apenas o texto reescrito, sem explicações."
+        ),
+        CorrectionPromptTemplate(
+            name: "Resumir em bullets",
+            systemPrompt: "Resuma o texto transcrito em uma lista curta de bullet points em português, destacando os pontos principais. Mantenha termos técnicos em inglês. Retorne apenas os bullets, sem introdução."
+        ),
+        CorrectionPromptTemplate(
+            name: "Traduzir para inglês",
+            systemPrompt: "Translate the transcribed text to natural, fluent English. Preserve technical terms and proper nouns. Return only the translated text, without explanations."
+        )
+    ]
 }

--- a/zspeak/Views/HistoryView.swift
+++ b/zspeak/Views/HistoryView.swift
@@ -9,40 +9,111 @@ struct HistoryView: View {
     @State private var playingRecordId: UUID?
     @State private var expandedRecordId: UUID?
     @State private var recordToDelete: TranscriptionRecord?
-    // Pagina\u00e7\u00e3o: carrega em blocos para n\u00e3o travar a UI com hist\u00f3ricos grandes
-    @State private var visibleCount: Int = 30
+    @State private var hoveredRecordId: UUID?
+    @State private var searchText: String = ""
+    // Paginação: carrega em blocos para não travar a UI com históricos grandes
+    @State private var visibleCount: Int = 50
 
-    private let pageSize: Int = 30
+    private let pageSize: Int = 50
+
+    // MARK: - Agrupamento
+
+    /// Grupos fixos, na ordem de exibição. Usado como chave estável das sections.
+    private enum DateGroup: Int, CaseIterable, Identifiable {
+        case today = 0
+        case yesterday
+        case thisWeek
+        case older
+
+        var id: Int { rawValue }
+
+        var title: String {
+            switch self {
+            case .today: return "Hoje"
+            case .yesterday: return "Ontem"
+            case .thisWeek: return "Esta semana"
+            case .older: return "Mais antigos"
+            }
+        }
+
+        static func classify(_ date: Date, now: Date = Date(), calendar: Calendar = .current) -> DateGroup {
+            if calendar.isDateInToday(date) { return .today }
+            if calendar.isDateInYesterday(date) { return .yesterday }
+            // "Esta semana" = últimos 7 dias (não semana do calendário), excluindo hoje/ontem já tratados.
+            if let sevenDaysAgo = calendar.date(byAdding: .day, value: -7, to: now),
+               date >= sevenDaysAgo {
+                return .thisWeek
+            }
+            return .older
+        }
+    }
+
+    // MARK: - Filtragem + agrupamento derivados
+
+    /// Normaliza string para busca diacritic-insensitive + case-insensitive.
+    private func normalize(_ s: String) -> String {
+        s.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: Locale(identifier: "pt-BR"))
+    }
+
+    /// Registros após aplicar busca. Mantém ordem original (mais recente primeiro).
+    private var filteredRecords: [TranscriptionRecord] {
+        let q = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !q.isEmpty else { return store.records }
+        let needle = normalize(q)
+        return store.records.filter { normalize($0.text).contains(needle) }
+    }
+
+    /// Registros paginados após filtro.
+    private var visibleRecords: [TranscriptionRecord] {
+        let all = filteredRecords
+        let limit = min(visibleCount, all.count)
+        return Array(all.prefix(limit))
+    }
+
+    /// Agrupa os records visíveis nos buckets de data, preservando ordem interna.
+    private var groupedVisibleRecords: [(group: DateGroup, records: [TranscriptionRecord])] {
+        var buckets: [DateGroup: [TranscriptionRecord]] = [:]
+        for r in visibleRecords {
+            buckets[DateGroup.classify(r.timestamp), default: []].append(r)
+        }
+        return DateGroup.allCases.compactMap { g in
+            guard let records = buckets[g], !records.isEmpty else { return nil }
+            return (g, records)
+        }
+    }
+
+    // MARK: - Body
 
     var body: some View {
         Form {
             if store.records.isEmpty {
-                ContentUnavailableView(
-                    "Nenhuma transcrição",
-                    systemImage: "text.bubble",
-                    description: Text("As transcrições aparecerão aqui conforme você usar o zspeak.")
-                )
+                emptyState
             } else {
-                let total = store.records.count
-                let limit = min(visibleCount, total)
-                ForEach(store.records.prefix(limit)) { record in
+                searchSection
+
+                let filteredTotal = filteredRecords.count
+
+                if filteredTotal == 0 {
                     Section {
-                        recordRow(record)
+                        ContentUnavailableView.search(text: searchText)
                     }
-                }
-                if limit < total {
-                    Section {
-                        HStack {
-                            Text("Mostrando \(limit) de \(total)")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Spacer()
-                            Button("Carregar mais \(min(pageSize, total - limit))") {
-                                visibleCount += pageSize
+                } else {
+                    ForEach(groupedVisibleRecords, id: \.group.id) { bucket in
+                        Section {
+                            ForEach(bucket.records) { record in
+                                recordRow(record)
+                                    .listRowInsets(EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8))
                             }
-                            .buttonStyle(.borderless)
+                        } header: {
+                            Text(bucket.group.title)
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(.secondary)
                         }
                     }
+
+                    // Rodapé de paginação: só aparece se houver mais pra mostrar
+                    // OU se já estivermos mostrando tudo acima de pageSize (feedback "Mostrando todos")
+                    paginationFooter(filteredTotal: filteredTotal)
                 }
             }
         }
@@ -50,10 +121,14 @@ struct HistoryView: View {
         .navigationTitle("Histórico")
         .onDisappear { stopAudio() }
         .onChange(of: store.records.count) { _, newCount in
-            // Mant\u00e9m o contador saud\u00e1vel se o usu\u00e1rio apagar itens
+            // Mantém o contador saudável se o usuário apagar itens
             if visibleCount > newCount {
                 visibleCount = max(pageSize, newCount)
             }
+        }
+        .onChange(of: searchText) { _, _ in
+            // Reset paginação ao mudar busca; hover e expansão seguem vivos.
+            visibleCount = pageSize
         }
         .alert("Apagar transcrição?", isPresented: .init(
             get: { recordToDelete != nil },
@@ -72,58 +147,159 @@ struct HistoryView: View {
         }
     }
 
-    // MARK: - Linha de cada registro
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        ContentUnavailableView(
+            "Nenhuma transcrição",
+            systemImage: "text.bubble",
+            description: Text(
+                "Pressione a tecla de ativação (⌘ direito, por padrão) para começar a falar. " +
+                "Cada transcrição ficará salva aqui com áudio e metadados."
+            )
+        )
+    }
+
+    // MARK: - Busca
+
+    @ViewBuilder
+    private var searchSection: some View {
+        Section {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField("Buscar no texto das transcrições", text: $searchText)
+                    .textFieldStyle(.plain)
+                    .accessibilityLabel("Buscar no histórico")
+                if !searchText.isEmpty {
+                    Button {
+                        searchText = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.borderless)
+                    .accessibilityLabel("Limpar busca")
+                }
+            }
+        }
+    }
+
+    // MARK: - Rodapé de paginação
+
+    @ViewBuilder
+    private func paginationFooter(filteredTotal: Int) -> some View {
+        let shown = min(visibleCount, filteredTotal)
+        // Esconde se a lista cabe inteira dentro de uma página
+        if filteredTotal > pageSize {
+            Section {
+                HStack {
+                    if shown < filteredTotal {
+                        let next = min(pageSize, filteredTotal - shown)
+                        Button("Mostrar próximos \(next)") {
+                            visibleCount += pageSize
+                        }
+                        .buttonStyle(.borderless)
+                        Spacer()
+                    } else {
+                        Text("Mostrando todos (\(filteredTotal))")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Linha compacta de cada registro
 
     @ViewBuilder
     private func recordRow(_ record: TranscriptionRecord) -> some View {
-        // Texto transcrito
+        let isExpanded = expandedRecordId == record.id
+        let isHovered = hoveredRecordId == record.id
+
         VStack(alignment: .leading, spacing: 4) {
-            let isExpanded = expandedRecordId == record.id
+            // Texto principal (tap expande)
             Text(record.text)
                 .lineLimit(isExpanded ? nil : 2)
                 .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
                 .onTapGesture {
-                    withAnimation(.easeInOut(duration: 0.2)) {
+                    withAnimation(.easeInOut(duration: 0.15)) {
                         expandedRecordId = isExpanded ? nil : record.id
                     }
                 }
 
-            // Badge de linkagem: se este record foi gerado a partir de outro
-            // Lookup O(1) via dict do store
+            // Badge "Corrigido de" — caption2, opacidade 0.7
             if let sourceID = record.sourceRecordID,
                let original = store.recordsByID[sourceID] {
                 HStack(spacing: 4) {
                     Image(systemName: "arrow.uturn.backward")
                     Text("Corrigido de: \(original.text.prefix(40))\(original.text.count > 40 ? "…" : "")")
+                        .lineLimit(1)
                 }
                 .font(.caption2)
                 .foregroundStyle(.secondary)
+                .opacity(0.7)
             }
-        }
 
-        // Metadados
-        HStack(spacing: 12) {
+            // Metadata + ações na mesma linha compacta
+            HStack(spacing: 8) {
+                metadataLine(record)
+                Spacer(minLength: 8)
+                actionButtons(record)
+            }
+            .padding(.top, 2)
+        }
+        .padding(.vertical, 2)
+        .padding(.horizontal, 4)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(isHovered ? Color.primary.opacity(0.06) : Color.clear)
+        )
+        .overlay(alignment: .bottom) {
+            // Separador sutil; não aparece no hover pra reforçar o destaque
+            Divider().opacity(isHovered ? 0 : 0.4)
+        }
+        .onHover { hovering in
+            hoveredRecordId = hovering ? record.id : (hoveredRecordId == record.id ? nil : hoveredRecordId)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel(for: record))
+    }
+
+    // MARK: - Metadata compacta
+
+    @ViewBuilder
+    private func metadataLine(_ record: TranscriptionRecord) -> some View {
+        HStack(spacing: 10) {
             Label(formattedTimestamp(record.timestamp), systemImage: "clock")
             Label(String(format: "%.1fs", record.duration), systemImage: "waveform")
-            Label(record.modelName, systemImage: "cpu")
             if let app = record.targetAppName {
                 Label(app, systemImage: "app")
+                    .lineLimit(1)
+                    .truncationMode(.middle)
             }
         }
-        .font(.caption)
+        .font(.caption2)
         .foregroundStyle(.secondary)
+    }
 
-        // Ações
-        HStack(spacing: 8) {
+    // MARK: - Botões de ação
+
+    @ViewBuilder
+    private func actionButtons(_ record: TranscriptionRecord) -> some View {
+        HStack(spacing: 6) {
             Button {
                 NSPasteboard.general.clearContents()
                 NSPasteboard.general.setString(record.text, forType: .string)
             } label: {
-                Label("Copiar", systemImage: "doc.on.doc")
+                Image(systemName: "doc.on.doc")
             }
+            .help("Copiar texto")
+            .accessibilityLabel("Copiar texto da transcrição")
 
-            // Botão "Ouvir" renderizado sempre que houver audioFileName.
-            // Checagem real de existência fica no tap (playAudio), evitando I/O no render.
             if record.audioFileName != nil {
                 Button {
                     if playingRecordId == record.id {
@@ -132,22 +308,22 @@ struct HistoryView: View {
                         playAudio(for: record)
                     }
                 } label: {
-                    Label(
-                        playingRecordId == record.id ? "Parar" : "Ouvir",
-                        systemImage: playingRecordId == record.id ? "stop.fill" : "play.fill"
-                    )
+                    Image(systemName: playingRecordId == record.id ? "stop.fill" : "play.fill")
                 }
+                .help(playingRecordId == record.id ? "Parar áudio" : "Ouvir áudio")
+                .accessibilityLabel(playingRecordId == record.id ? "Parar áudio" : "Ouvir áudio")
             }
-
-            Spacer()
 
             Button(role: .destructive) {
                 recordToDelete = record
             } label: {
-                Label("Apagar", systemImage: "trash")
+                Image(systemName: "trash")
             }
+            .help("Apagar transcrição")
+            .accessibilityLabel("Apagar transcrição")
         }
         .buttonStyle(.borderless)
+        .font(.callout)
     }
 
     // MARK: - Player de áudio
@@ -173,5 +349,14 @@ struct HistoryView: View {
         formatter.locale = Locale(identifier: "pt-BR")
         formatter.unitsStyle = .short
         return formatter.localizedString(for: date, relativeTo: Date())
+    }
+
+    private func accessibilityLabel(for record: TranscriptionRecord) -> String {
+        let snippet = record.text.count > 120
+            ? "\(record.text.prefix(120))…"
+            : record.text
+        let app = record.targetAppName.map { ", em \($0)" } ?? ""
+        return "Transcrição de \(formattedTimestamp(record.timestamp)), " +
+               "\(String(format: "%.1f", record.duration)) segundos\(app). \(snippet)"
     }
 }

--- a/zspeak/Views/MenuBarView.swift
+++ b/zspeak/Views/MenuBarView.swift
@@ -1,15 +1,22 @@
 import SwiftUI
 
-/// Menu do ícone no menu bar
+/// Menu do ícone no menu bar.
+///
+/// Dependências injetadas via `@Environment` (mesmas classes @Observable
+/// também consumidas por `SettingsView`). Para abrir a janela de Settings usa
+/// `openSettings` (macOS 14+); a aba inicial é comunicada via
+/// `@AppStorage("settings.initialPage")` — SettingsView observa esse storage e
+/// sincroniza `selectedPage`. Para a janela de arquivo usa `openWindow(id:)`.
 struct MenuBarView: View {
-    let appState: AppState
-    let activationKeyManager: ActivationKeyManager
-    let accessibilityManager: AccessibilityManager
-    let store: TranscriptionStore
-    let benchmarkStore: BenchmarkStore
-    let vocabularyStore: VocabularyStore
-    let correctionPromptStore: CorrectionPromptStore
-    let promptModeManager: PromptModeManager
+    @Environment(AppState.self) private var appState
+    @Environment(AccessibilityManager.self) private var accessibilityManager
+    @Environment(TranscriptionStore.self) private var store
+    @Environment(PromptModeManager.self) private var promptModeManager
+
+    @Environment(\.openSettings) private var openSettings
+    @Environment(\.openWindow) private var openWindow
+
+    @AppStorage("settings.initialPage") private var initialSettingsPage: String = SettingsPage.overview.rawValue
 
     var body: some View {
         // Indicador do Modo Prompt LLM
@@ -48,7 +55,7 @@ struct MenuBarView: View {
                     .foregroundStyle(.secondary)
             } else {
                 Button("Configurar Microfone...") {
-                    appState.microphoneManager.openSystemSettings()
+                    openSettingsOn(.permissions)
                 }
             }
         }
@@ -58,7 +65,7 @@ struct MenuBarView: View {
                 .foregroundStyle(.orange)
                 .font(.caption)
             Button("Configurar Acessibilidade...") {
-                accessibilityManager.openSystemSettings()
+                openSettingsOn(.permissions)
             }
         }
 
@@ -106,26 +113,16 @@ struct MenuBarView: View {
             Divider()
         }
 
-        // Transcrever arquivo de áudio
+        // Transcrever arquivo de áudio — abre janela flutuante dedicada
         Button("Transcrever arquivo...") {
-            SettingsWindowController.shared.show(
-                appState: appState,
-                microphoneManager: appState.microphoneManager,
-                activationKeyManager: activationKeyManager,
-                accessibilityManager: accessibilityManager,
-                store: store,
-                benchmarkStore: benchmarkStore,
-                vocabularyStore: vocabularyStore,
-                correctionPromptStore: correctionPromptStore,
-                initialPage: .audioFile
-            )
+            openWindow(id: AudioFileWindowID.value)
         }
         .keyboardShortcut("t", modifiers: [.command, .shift])
         .disabled(!appState.isModelReady)
 
         // Configurações e sair
         Button("Configurações...") {
-            SettingsWindowController.shared.show(appState: appState, microphoneManager: appState.microphoneManager, activationKeyManager: activationKeyManager, accessibilityManager: accessibilityManager, store: store, benchmarkStore: benchmarkStore, vocabularyStore: vocabularyStore, correctionPromptStore: correctionPromptStore)
+            openSettingsOn(.overview)
         }
         .keyboardShortcut(",", modifiers: [.command])
 
@@ -133,6 +130,14 @@ struct MenuBarView: View {
             NSApplication.shared.terminate(nil)
         }
         .keyboardShortcut("q", modifiers: [.command])
+    }
+
+    /// Seta a aba inicial desejada e abre Settings. Como `SettingsView` observa
+    /// o `@AppStorage`, a aba correta é selecionada mesmo se a janela já estava
+    /// aberta.
+    private func openSettingsOn(_ page: SettingsPage) {
+        initialSettingsPage = page.rawValue
+        openSettings()
     }
 
     private var statusColor: Color {

--- a/zspeak/Views/Settings/AboutPage.swift
+++ b/zspeak/Views/Settings/AboutPage.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+import AppKit
+
+/// Página "Sobre" — logo, versão, informações de processamento e links.
+struct AboutPage: View {
+
+    private var appVersion: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+    }
+
+    private var buildNumber: String {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                HStack {
+                    Spacer()
+                    VStack(spacing: 6) {
+                        Image(systemName: "waveform.badge.mic")
+                            .font(.system(size: 48))
+                            .foregroundStyle(Color.accentColor)
+                            .padding(.top, 8)
+
+                        Text("zspeak")
+                            .font(.title2)
+                            .fontWeight(.semibold)
+
+                        Text("versão \(appVersion) (\(buildNumber))")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 8)
+                    Spacer()
+                }
+            }
+
+            Section("Tecnologia") {
+                LabeledContent("Modelo ASR", value: "Parakeet TDT 0.6B V3")
+                LabeledContent("Motor", value: "FluidAudio (CoreML / ANE)")
+                LabeledContent("Processamento", value: "100% local")
+            }
+
+            Section("Plataforma") {
+                LabeledContent("Sistema", value: "macOS 14+ (Apple Silicon)")
+                LabeledContent("Privacidade", value: "Nenhum dado sai do dispositivo")
+            }
+
+            Section("Links") {
+                Button {
+                    if let url = URL(string: "https://github.com/michelzandonai/zspeak") {
+                        NSWorkspace.shared.open(url)
+                    }
+                } label: {
+                    Label("Abrir repositório no GitHub", systemImage: "chevron.left.forwardslash.chevron.right")
+                }
+
+                // TODO: implementar em onda futura
+                Button {
+                    // placeholder não-funcional
+                } label: {
+                    Label("Verificar atualizações", systemImage: "arrow.triangle.2.circlepath")
+                }
+                .disabled(true)
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle("Sobre")
+    }
+}

--- a/zspeak/Views/Settings/GeneralPage.swift
+++ b/zspeak/Views/Settings/GeneralPage.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+import AppKit
+import LaunchAtLogin
+
+/// Modo de inserção de texto após transcrição.
+enum PasteMode: String, CaseIterable, Identifiable {
+    case instant    // cola automático no app ativo (requer Accessibility)
+    case clipboard  // só copia para o clipboard, usuário decide onde colar
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .instant: return "Colar automaticamente"
+        case .clipboard: return "Apenas copiar para o clipboard"
+        }
+    }
+}
+
+/// Página Geral — toggles amplos que afetam o app inteiro.
+struct GeneralPage: View {
+    @AppStorage("pasteMode") private var pasteModeRaw: String = PasteMode.instant.rawValue
+    @AppStorage("playRecordingSounds") private var playRecordingSounds: Bool = false
+    @AppStorage("showOverlayLatency") private var showOverlayLatency: Bool = false
+
+    private var pasteMode: Binding<PasteMode> {
+        Binding(
+            get: { PasteMode(rawValue: pasteModeRaw) ?? .instant },
+            set: { pasteModeRaw = $0.rawValue }
+        )
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                LaunchAtLogin.Toggle("Iniciar com o sistema")
+            } footer: {
+                Text("Abre o zspeak automaticamente quando você faz login no macOS.")
+            }
+
+            Section {
+                Picker("Após a transcrição", selection: pasteMode) {
+                    ForEach(PasteMode.allCases) { mode in
+                        Text(mode.label).tag(mode)
+                    }
+                }
+                .pickerStyle(.inline)
+                .labelsHidden()
+            } header: {
+                Text("Inserção de texto")
+            } footer: {
+                Text("\"Colar automaticamente\" simula ⌘+V no app ativo (precisa de Acessibilidade). \"Apenas copiar\" deixa o texto no clipboard para você colar quando quiser.")
+            }
+
+            Section {
+                Toggle("Tocar som no início e no fim da gravação", isOn: $playRecordingSounds)
+            } footer: {
+                Text("Usa o bip padrão do sistema como feedback sonoro — útil quando o overlay está fora da visão.")
+            }
+
+            Section {
+                Toggle("Mostrar latência no overlay", isOn: $showOverlayLatency)
+            } footer: {
+                Text("Exibe o tempo entre apertar a hotkey e o primeiro sample capturado. Útil para debug.")
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle("Geral")
+    }
+}

--- a/zspeak/Views/Settings/KeyboardPage.swift
+++ b/zspeak/Views/Settings/KeyboardPage.swift
@@ -1,0 +1,107 @@
+import SwiftUI
+import KeyboardShortcuts
+
+/// Página de Atalhos de Teclado.
+///
+/// Mostra um preview visual do atalho atual no topo, deixa o usuário trocar a
+/// tecla de ativação e o modo (toggle/hold/doubleTap), e expõe o atalho global
+/// do Modo Prompt LLM. A ajuda sobre os modos aparece AO LADO do picker — não
+/// em footer de outra seção — para que fique claro o que cada modo faz.
+struct KeyboardPage: View {
+    @Environment(ActivationKeyManager.self) private var activationKeyManager
+
+    var body: some View {
+        @Bindable var keyManager = activationKeyManager
+
+        Form {
+            Section {
+                shortcutPreview
+            }
+
+            Section {
+                Picker("Tecla", selection: $keyManager.selectedKey) {
+                    ForEach(ActivationKey.allCases) { key in
+                        Text(key.rawValue).tag(key)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Picker("Modo", selection: $keyManager.activationMode) {
+                        ForEach(ActivationMode.allCases, id: \.self) { mode in
+                            Text(mode.rawValue).tag(mode)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+
+                    Text(modeDescription(for: keyManager.activationMode))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            } header: {
+                Text("Tecla de ativação")
+            }
+
+            Section {
+                KeyboardShortcuts.Recorder("Modo Prompt LLM:", name: .togglePromptMode)
+            } header: {
+                Text("Correção LLM")
+            } footer: {
+                Text("Atalho global para ligar/desligar o Modo Prompt. Quando ativo, o overlay fica visível com chips de prompts clicáveis. ESC também desliga.")
+            }
+
+            Section {
+                Toggle("Escape cancela gravação", isOn: $keyManager.escapeToCancel)
+            } footer: {
+                Text("Permite interromper uma gravação em andamento sem transcrever, pressionando ESC.")
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle("Atalhos de Teclado")
+    }
+
+    // MARK: - Preview do atalho atual
+
+    private var shortcutPreview: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "keyboard")
+                .font(.title2)
+                .foregroundStyle(Color.accentColor)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Atalho atual")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                HStack(spacing: 6) {
+                    shortcutBadge(text: activationKeyManager.selectedKey.rawValue)
+                    Text("para")
+                        .foregroundStyle(.secondary)
+                    shortcutBadge(text: activationKeyManager.activationMode.rawValue)
+                }
+                .font(.body)
+            }
+
+            Spacer()
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func shortcutBadge(text: String) -> some View {
+        Text(text)
+            .font(.body.monospaced())
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(.quaternary, in: RoundedRectangle(cornerRadius: 5))
+    }
+
+    private func modeDescription(for mode: ActivationMode) -> String {
+        switch mode {
+        case .toggle:
+            return "Toggle: toque a tecla para começar, toque de novo para parar."
+        case .hold:
+            return "Hold: mantenha a tecla pressionada enquanto grava; solte para parar."
+        case .doubleTap:
+            return "Double Tap: toque duas vezes rapidamente para iniciar; toque duas vezes para parar."
+        }
+    }
+}

--- a/zspeak/Views/Settings/MicrophonePage.swift
+++ b/zspeak/Views/Settings/MicrophonePage.swift
@@ -1,0 +1,106 @@
+import SwiftUI
+
+/// Página de Microfone.
+///
+/// Lista dispositivos disponíveis e permite reordenar via `List.onMove` (drag).
+/// Badges indicam o microfone **Ativo** (em uso agora) e o **Preferido** (o que
+/// será tentado primeiro na próxima gravação). O toggle "Usar padrão do sistema"
+/// esconde/mostra a lista com transição animada.
+struct MicrophonePage: View {
+    @Environment(MicrophoneManager.self) private var microphoneManager
+
+    var body: some View {
+        @Bindable var mic = microphoneManager
+
+        Form {
+            Section {
+                Toggle("Usar padrão do sistema", isOn: $mic.useSystemDefault)
+            } footer: {
+                Text("Quando ligado, zspeak usa sempre o microfone padrão do sistema. Desligue para definir uma ordem de prioridade.")
+            }
+
+            if !microphoneManager.useSystemDefault {
+                Section {
+                    List {
+                        ForEach(microphoneManager.microphones) { mic in
+                            micRow(for: mic)
+                        }
+                        .onMove { offsets, destination in
+                            microphoneManager.reorder(fromOffsets: offsets, toOffset: destination)
+                        }
+                    }
+                    .frame(minHeight: rowHeight * CGFloat(max(microphoneManager.microphones.count, 1)))
+                } header: {
+                    Text("Ordem de prioridade")
+                } footer: {
+                    Text("Arraste para reordenar. zspeak tenta cada microfone conectado na ordem acima.")
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle("Microfone")
+        .animation(.default, value: microphoneManager.useSystemDefault)
+    }
+
+    // MARK: - Linha
+
+    private let rowHeight: CGFloat = 32
+
+    @ViewBuilder
+    private func micRow(for mic: MicrophoneInfo) -> some View {
+        let isActive = microphoneManager.activeMicrophoneID == mic.id
+        let isPreferred = preferredMicrophoneID == mic.id && !isActive
+
+        HStack(spacing: 8) {
+            Image(systemName: iconName(for: mic, isActive: isActive))
+                .foregroundStyle(iconColor(for: mic, isActive: isActive))
+                .frame(width: 16)
+
+            Text(mic.name)
+                .foregroundStyle(mic.isConnected ? .primary : .secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            Spacer(minLength: 8)
+
+            if isActive {
+                badge(text: "Ativo", color: .red)
+            } else if isPreferred {
+                badge(text: "Preferido", color: .green)
+            } else if !mic.isConnected {
+                badge(text: "Desconectado", color: .secondary)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private func iconName(for mic: MicrophoneInfo, isActive: Bool) -> String {
+        if isActive { return "mic.fill" }
+        if !mic.isConnected { return "mic.slash" }
+        return "mic"
+    }
+
+    private func iconColor(for mic: MicrophoneInfo, isActive: Bool) -> Color {
+        if isActive { return .red }
+        if !mic.isConnected { return .secondary }
+        return .primary
+    }
+
+    private func badge(text: String, color: Color) -> some View {
+        Text(text)
+            .font(.caption2)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.15), in: Capsule())
+            .foregroundStyle(color)
+    }
+
+    /// ID do microfone que será usado na próxima gravação: ativo (durante gravação)
+    /// ou o primeiro conectado da lista ordenada.
+    private var preferredMicrophoneID: String? {
+        if let activeID = microphoneManager.activeMicrophoneID {
+            return activeID
+        }
+        return microphoneManager.microphones.first(where: \.isConnected)?.id
+    }
+}

--- a/zspeak/Views/Settings/OverviewPage.swift
+++ b/zspeak/Views/Settings/OverviewPage.swift
@@ -1,0 +1,218 @@
+import SwiftUI
+
+/// Página de Overview — "dashboard" do estado do app.
+///
+/// Mostra um header grande com status agregado (verde = tudo ok, laranja = algo
+/// pedindo atenção) e cards com as informações mais relevantes: ASR, LLM,
+/// permissões, atalho, última transcrição. Inclui CTAs contextuais para
+/// navegar direto na aba certa quando algo está faltando.
+struct OverviewPage: View {
+    @Environment(AppState.self) private var appState
+    @Environment(MicrophoneManager.self) private var microphoneManager
+    @Environment(AccessibilityManager.self) private var accessibilityManager
+    @Environment(ActivationKeyManager.self) private var activationKeyManager
+    @Environment(TranscriptionStore.self) private var store
+
+    @AppStorage("settings.initialPage") private var initialPage: String = "overview"
+
+    @State private var llmState: LLMCorrectionManager.ModelState = .notDownloaded
+
+    var body: some View {
+        Form {
+            Section { summaryHeader }
+
+            Section("Status") {
+                asrStatusRow
+                llmStatusRow
+                permissionsStatusRow
+                shortcutRow
+            }
+
+            if let last = lastTranscriptionSnippet {
+                Section("Última transcrição") {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(last.text)
+                            .lineLimit(3)
+                            .foregroundStyle(.primary)
+                        Text(last.relative)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle("Visão Geral")
+        .task(id: llmStateTaskID) {
+            llmState = await appState.llmModelState()
+        }
+    }
+
+    // MARK: - Header agregado
+
+    private var summaryHeader: some View {
+        let issues = attentionIssues
+        let allGood = issues.isEmpty
+
+        return VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 12) {
+                Image(systemName: allGood ? "checkmark.seal.fill" : "exclamationmark.triangle.fill")
+                    .font(.system(size: 32))
+                    .foregroundStyle(allGood ? .green : .orange)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(allGood ? "Tudo funcionando" : "Atenção necessária")
+                        .font(.title3)
+                        .fontWeight(.semibold)
+                    Text(allGood
+                         ? "zspeak está pronto para transcrever."
+                         : "Verifique os itens abaixo para liberar todas as funcionalidades."
+                    )
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Linhas de status
+
+    private var asrStatusRow: some View {
+        statusRow(
+            icon: "waveform",
+            title: "Modelo de transcrição",
+            status: asrStatus.text,
+            color: asrStatus.color
+        )
+    }
+
+    private var llmStatusRow: some View {
+        HStack {
+            statusRow(
+                icon: "sparkles",
+                title: "Correção LLM",
+                status: llmStatusText,
+                color: llmStatusColor
+            )
+            if case .notDownloaded = llmState {
+                Spacer()
+                Button("Configurar") {
+                    initialPage = "correction"
+                }
+                .controlSize(.small)
+            }
+        }
+    }
+
+    private var permissionsStatusRow: some View {
+        HStack {
+            let pending = pendingPermissions
+            statusRow(
+                icon: "lock.shield",
+                title: "Permissões",
+                status: pending.isEmpty ? "Todas concedidas" : "\(pending.count) pendente\(pending.count == 1 ? "" : "s")",
+                color: pending.isEmpty ? .green : .orange
+            )
+            if !pending.isEmpty {
+                Spacer()
+                Button("Abrir Permissões") {
+                    initialPage = "permissions"
+                }
+                .controlSize(.small)
+            }
+        }
+    }
+
+    private var shortcutRow: some View {
+        HStack {
+            statusRow(
+                icon: "keyboard",
+                title: "Atalho",
+                status: "\(activationKeyManager.selectedKey.rawValue) · \(activationKeyManager.activationMode.rawValue)",
+                color: .secondary
+            )
+            Spacer()
+            Button("Editar") {
+                initialPage = "keyboard"
+            }
+            .controlSize(.small)
+        }
+    }
+
+    @ViewBuilder
+    private func statusRow(icon: String, title: String, status: String, color: Color) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: icon)
+                .foregroundStyle(color == .secondary ? .secondary : color)
+                .frame(width: 18)
+            Text(title)
+            Spacer()
+            Text(status)
+                .foregroundStyle(color == .secondary ? .secondary : color)
+                .font(.callout)
+        }
+    }
+
+    // MARK: - Dados derivados
+
+    private var asrStatus: (text: String, color: Color) {
+        if appState.isModelReady { return ("Pronto", .green) }
+        return ("Carregando...", .orange)
+    }
+
+    private var llmStatusText: String {
+        switch llmState {
+        case .notDownloaded: return "Não baixado"
+        case .downloading(let progress): return "Baixando (\(Int(progress * 100))%)"
+        case .downloaded: return "Baixado"
+        case .loading: return "Carregando..."
+        case .ready: return "Pronto"
+        case .error: return "Erro"
+        }
+    }
+
+    private var llmStatusColor: Color {
+        switch llmState {
+        case .notDownloaded: return .secondary
+        case .downloading, .loading: return .orange
+        case .downloaded, .ready: return .green
+        case .error: return .red
+        }
+    }
+
+    /// Força re-execução do .task quando o estado observado muda.
+    private var llmStateTaskID: Int {
+        appState.isModelReady ? 1 : 0
+    }
+
+    private var pendingPermissions: [String] {
+        var list: [String] = []
+        if !microphoneManager.isPermissionGranted { list.append("Microfone") }
+        if !accessibilityManager.isGranted { list.append("Acessibilidade") }
+        return list
+    }
+
+    private var attentionIssues: [String] {
+        var issues: [String] = []
+        if !appState.isModelReady { issues.append("Modelo ASR carregando") }
+        issues.append(contentsOf: pendingPermissions.map { "\($0) pendente" })
+        return issues
+    }
+
+    private var lastTranscriptionSnippet: (text: String, relative: String)? {
+        if let record = store.records.first {
+            return (record.text, relativeDate(record.timestamp))
+        }
+        let fallback = appState.lastTranscription
+        guard !fallback.isEmpty else { return nil }
+        return (fallback, "agora")
+    }
+
+    private func relativeDate(_ date: Date) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        formatter.locale = Locale(identifier: "pt_BR")
+        return formatter.localizedString(for: date, relativeTo: Date())
+    }
+}

--- a/zspeak/Views/Settings/PermissionsPage.swift
+++ b/zspeak/Views/Settings/PermissionsPage.swift
@@ -1,0 +1,216 @@
+import SwiftUI
+
+/// Página de Permissões.
+///
+/// Header agregado no topo informa se está tudo concedido ou se algo precisa
+/// de atenção. Cada permissão aparece numa section com status visual e CTA
+/// consistente; os passos "Como ativar" só aparecem quando a permissão está
+/// pendente, para não poluir a UI quando tudo já está ok.
+struct PermissionsPage: View {
+    @Environment(MicrophoneManager.self) private var microphoneManager
+    @Environment(AccessibilityManager.self) private var accessibilityManager
+
+    var body: some View {
+        Form {
+            Section { summaryHeader }
+
+            // Microfone
+            Section {
+                permissionRow(
+                    title: "Microfone",
+                    granted: microphoneManager.isPermissionGranted,
+                    iconName: microphoneStatusIcon,
+                    iconColor: microphoneStatusColor,
+                    action: microphoneAction
+                )
+            } footer: {
+                Text(microphonePermissionFooter)
+            }
+
+            if !microphoneManager.isPermissionGranted && microphoneManager.permissionState != .unavailable {
+                Section("Como ativar o microfone") {
+                    Label("Clique em \"Solicitar Permissão\" ou inicie uma gravação", systemImage: "1.circle")
+                    Label("Se o macOS negar, abra Ajustes do Sistema", systemImage: "2.circle")
+                    Label("Ative zspeak em Privacidade → Microfone", systemImage: "3.circle")
+                }
+            }
+
+            // Acessibilidade
+            Section {
+                permissionRow(
+                    title: "Acessibilidade",
+                    granted: accessibilityManager.isGranted,
+                    iconName: accessibilityManager.isGranted ? "checkmark.circle.fill" : "exclamationmark.triangle.fill",
+                    iconColor: accessibilityManager.isGranted ? .green : .orange,
+                    action: accessibilityAction
+                )
+            } footer: {
+                Text("Necessário para colar no app ativo e para a hotkey global. Sem isso, a transcrição continua funcionando com cópia para o clipboard.")
+            }
+
+            if !accessibilityManager.isGranted {
+                Section("Como ativar a acessibilidade") {
+                    Label("Clique em \"Abrir Ajustes do Sistema\"", systemImage: "1.circle")
+                    Label("Encontre \"zspeak\" na lista", systemImage: "2.circle")
+                    Label("Ative o toggle", systemImage: "3.circle")
+                }
+
+                Section("Resolução de problemas") {
+                    Text("Se zspeak não aparece na lista: clique \"+\" e navegue até /Applications/zspeak.app")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                    Text("Se o toggle está ativo mas aqui mostra inativo: remova da lista, adicione novamente e reinicie o app.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            // Build sem Info.plist — mostrar apenas no caso técnico
+            if microphoneManager.permissionState == .unavailable {
+                Section("Build") {
+                    Text("O build atual não expõe permissão de microfone. Isso acontece quando o app é rodado fora de um bundle .app com Info.plist embutido.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle("Permissões")
+    }
+
+    // MARK: - Header agregado
+
+    private var summaryHeader: some View {
+        let pending = pendingCount
+        let allGranted = pending == 0
+
+        return HStack(spacing: 10) {
+            Image(systemName: allGranted ? "checkmark.seal.fill" : "exclamationmark.triangle.fill")
+                .font(.title2)
+                .foregroundStyle(allGranted ? .green : .orange)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(allGranted ? "Tudo concedido" : "Atenção necessária")
+                    .font(.headline)
+                Text(allGranted
+                     ? "zspeak tem todas as permissões para funcionar completamente."
+                     : "\(pending) permissão\(pending == 1 ? "" : "es") faltando para o app funcionar completamente."
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var pendingCount: Int {
+        var count = 0
+        if !microphoneManager.isPermissionGranted { count += 1 }
+        if !accessibilityManager.isGranted { count += 1 }
+        return count
+    }
+
+    // MARK: - Linha de permissão
+
+    @ViewBuilder
+    private func permissionRow(
+        title: String,
+        granted: Bool,
+        iconName: String,
+        iconColor: Color,
+        action: PermissionAction?
+    ) -> some View {
+        HStack {
+            Label {
+                Text(title)
+            } icon: {
+                Image(systemName: iconName)
+                    .foregroundStyle(iconColor)
+            }
+
+            Spacer()
+
+            if granted {
+                statusChip(text: "Concedido", color: .green)
+            } else {
+                statusChip(text: "Pendente", color: .orange)
+                if let action {
+                    Button(action.label, action: action.run)
+                        .controlSize(.small)
+                }
+            }
+        }
+    }
+
+    private func statusChip(text: String, color: Color) -> some View {
+        Text(text)
+            .font(.caption)
+            .foregroundStyle(color)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 2)
+            .background(color.opacity(0.12), in: Capsule())
+    }
+
+    // MARK: - Ações
+
+    private struct PermissionAction {
+        let label: String
+        let run: () -> Void
+    }
+
+    private var microphoneAction: PermissionAction? {
+        switch microphoneManager.permissionState {
+        case .authorized, .unavailable:
+            return nil
+        case .notDetermined:
+            return PermissionAction(label: "Conceder") {
+                Task {
+                    _ = await microphoneManager.requestPermissionIfNeeded()
+                }
+            }
+        case .denied, .restricted:
+            return PermissionAction(label: "Abrir Ajustes") {
+                microphoneManager.openSystemSettings()
+            }
+        }
+    }
+
+    private var accessibilityAction: PermissionAction? {
+        guard !accessibilityManager.isGranted else { return nil }
+        return PermissionAction(label: "Abrir Ajustes") {
+            accessibilityManager.openSystemSettings()
+        }
+    }
+
+    // MARK: - Strings específicas de microfone
+
+    private var microphoneStatusIcon: String {
+        switch microphoneManager.permissionState {
+        case .authorized: return "checkmark.circle.fill"
+        case .notDetermined: return "questionmark.circle.fill"
+        case .denied, .restricted, .unavailable: return "exclamationmark.triangle.fill"
+        }
+    }
+
+    private var microphoneStatusColor: Color {
+        switch microphoneManager.permissionState {
+        case .authorized: return .green
+        case .notDetermined: return .yellow
+        case .denied, .restricted, .unavailable: return .orange
+        }
+    }
+
+    private var microphonePermissionFooter: String {
+        switch microphoneManager.permissionState {
+        case .authorized:
+            return "Obrigatório para capturar sua voz e iniciar a transcrição."
+        case .notDetermined:
+            return "A primeira gravação vai solicitar acesso ao microfone."
+        case .denied, .restricted:
+            return "Sem acesso ao microfone a gravação não inicia."
+        case .unavailable:
+            return "Build atual não expõe permissão de microfone — rode via bundle .app em /Applications."
+        }
+    }
+}

--- a/zspeak/Views/SettingsView.swift
+++ b/zspeak/Views/SettingsView.swift
@@ -1,110 +1,43 @@
 import SwiftUI
-import AppKit
-import LaunchAtLogin
-import KeyboardShortcuts
-
-// MARK: - Window Controller
-
-@MainActor
-final class SettingsWindowController {
-    static let shared = SettingsWindowController()
-    private var window: NSWindow?
-    private var currentHostingView: NSHostingView<SettingsView>?
-
-    func show(
-        appState: AppState,
-        microphoneManager: MicrophoneManager,
-        activationKeyManager: ActivationKeyManager,
-        accessibilityManager: AccessibilityManager,
-        store: TranscriptionStore,
-        benchmarkStore: BenchmarkStore,
-        vocabularyStore: VocabularyStore,
-        correctionPromptStore: CorrectionPromptStore,
-        initialPage: SettingsPage? = nil
-    ) {
-        if let window = window, window.isVisible {
-            window.level = .floating
-            window.makeKeyAndOrderFront(nil)
-            NSApp.activate()
-            // Se foi pedida uma página específica, reconstrói a view com initialPage
-            if let initialPage {
-                let updatedView = SettingsView(
-                    appState: appState,
-                    microphoneManager: microphoneManager,
-                    activationKeyManager: activationKeyManager,
-                    accessibilityManager: accessibilityManager,
-                    store: store,
-                    benchmarkStore: benchmarkStore,
-                    vocabularyStore: vocabularyStore,
-                    correctionPromptStore: correctionPromptStore,
-                    initialPage: initialPage
-                )
-                let hostingView = NSHostingView(rootView: updatedView)
-                window.contentView = hostingView
-                self.currentHostingView = hostingView
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                window.level = .normal
-            }
-            return
-        }
-
-        let settingsView = SettingsView(
-            appState: appState,
-            microphoneManager: microphoneManager,
-            activationKeyManager: activationKeyManager,
-            accessibilityManager: accessibilityManager,
-            store: store,
-            benchmarkStore: benchmarkStore,
-            vocabularyStore: vocabularyStore,
-            correctionPromptStore: correctionPromptStore,
-            initialPage: initialPage
-        )
-        let hostingView = NSHostingView(rootView: settingsView)
-        self.currentHostingView = hostingView
-
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 700, height: 500),
-            styleMask: [.titled, .closable, .resizable],
-            backing: .buffered,
-            defer: false
-        )
-        window.minSize = NSSize(width: 620, height: 420)
-        window.title = "zspeak — Configurações"
-        window.contentView = hostingView
-        window.center()
-        window.isReleasedWhenClosed = false
-        window.level = .floating
-        window.makeKeyAndOrderFront(nil)
-        NSApp.activate()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            window.level = .normal
-        }
-
-        self.window = window
-    }
-}
 
 // MARK: - Sidebar navigation
 
+/// Enum das páginas de Settings. `rawValue` é estável (usado em
+/// `@AppStorage("settings.initialPage")`), separado do título legível via
+/// `title`.
 enum SettingsPage: String, CaseIterable, Identifiable {
-    case history = "Histórico"
-    case audioFile = "Transcrever Arquivo"
-    case benchmark = "Benchmark"
-    case vocabulary = "Vocabulário"
-    case correction = "Correção LLM"
-    case keyboard = "Atalhos de Teclado"
-    case microphone = "Microfone"
-    case general = "Geral"
-    case permissions = "Permissões"
-    case about = "Sobre"
+    case overview = "overview"
+    case history = "history"
+    case benchmark = "benchmark"
+    case vocabulary = "vocabulary"
+    case correction = "correction"
+    case keyboard = "keyboard"
+    case microphone = "microphone"
+    case general = "general"
+    case permissions = "permissions"
+    case about = "about"
 
     var id: String { rawValue }
 
+    var title: String {
+        switch self {
+        case .overview: "Visão Geral"
+        case .history: "Histórico"
+        case .benchmark: "Benchmark"
+        case .vocabulary: "Vocabulário"
+        case .correction: "Correção LLM"
+        case .keyboard: "Atalhos de Teclado"
+        case .microphone: "Microfone"
+        case .general: "Geral"
+        case .permissions: "Permissões"
+        case .about: "Sobre"
+        }
+    }
+
     var icon: String {
         switch self {
+        case .overview: "square.grid.2x2"
         case .history: "clock.arrow.circlepath"
-        case .audioFile: "waveform.badge.plus"
         case .benchmark: "gauge.with.needle"
         case .vocabulary: "text.book.closed"
         case .correction: "sparkles"
@@ -115,64 +48,84 @@ enum SettingsPage: String, CaseIterable, Identifiable {
         case .about: "info.circle"
         }
     }
+
+    /// Seção da sidebar onde a página aparece.
+    enum Section: String, CaseIterable {
+        case content = "Conteúdo"
+        case configuration = "Configurações"
+        case system = "Sistema"
+    }
+
+    var section: Section {
+        switch self {
+        case .overview, .history, .benchmark: .content
+        case .vocabulary, .correction, .keyboard, .microphone, .general: .configuration
+        case .permissions, .about: .system
+        }
+    }
 }
 
 // MARK: - Settings View
 
+/// Tela principal de Settings. Não possui init customizado: todas as
+/// dependências vêm via `@Environment` injetado em `App.swift`. A página
+/// inicial é controlada por `@AppStorage("settings.initialPage")`, permitindo
+/// que o MenuBar abra a janela já na aba certa.
 struct SettingsView: View {
-    let appState: AppState
-    @Bindable var microphoneManager: MicrophoneManager
-    @Bindable var activationKeyManager: ActivationKeyManager
-    var accessibilityManager: AccessibilityManager
-    let store: TranscriptionStore
-    @Bindable var benchmarkStore: BenchmarkStore
-    @Bindable var vocabularyStore: VocabularyStore
-    @Bindable var correctionPromptStore: CorrectionPromptStore
+    @Environment(AppState.self) private var appState
+    @Environment(MicrophoneManager.self) private var microphoneManager
+    @Environment(ActivationKeyManager.self) private var activationKeyManager
+    @Environment(AccessibilityManager.self) private var accessibilityManager
+    @Environment(TranscriptionStore.self) private var store
+    @Environment(BenchmarkStore.self) private var benchmarkStore
+    @Environment(VocabularyStore.self) private var vocabularyStore
+    @Environment(CorrectionPromptStore.self) private var correctionPromptStore
 
-    @State private var selectedPage: SettingsPage
+    @AppStorage("settings.initialPage") private var initialPageRaw: String = SettingsPage.overview.rawValue
 
-    init(
-        appState: AppState,
-        microphoneManager: MicrophoneManager,
-        activationKeyManager: ActivationKeyManager,
-        accessibilityManager: AccessibilityManager,
-        store: TranscriptionStore,
-        benchmarkStore: BenchmarkStore,
-        vocabularyStore: VocabularyStore,
-        correctionPromptStore: CorrectionPromptStore,
-        initialPage: SettingsPage? = nil
-    ) {
-        self.appState = appState
-        self.microphoneManager = microphoneManager
-        self.activationKeyManager = activationKeyManager
-        self.accessibilityManager = accessibilityManager
-        self.store = store
-        self.benchmarkStore = benchmarkStore
-        self.vocabularyStore = vocabularyStore
-        self.correctionPromptStore = correctionPromptStore
-        self._selectedPage = State(initialValue: initialPage ?? .general)
-    }
+    @State private var selectedPage: SettingsPage = .overview
 
     var body: some View {
         NavigationSplitView {
-            List(SettingsPage.allCases, selection: $selectedPage) { page in
-                Label(page.rawValue, systemImage: page.icon)
-                    .tag(page)
+            List(selection: $selectedPage) {
+                ForEach(SettingsPage.Section.allCases, id: \.self) { section in
+                    Section(section.rawValue) {
+                        ForEach(pages(in: section)) { page in
+                            Label(page.title, systemImage: page.icon)
+                                .tag(page)
+                        }
+                    }
+                }
             }
-            .navigationSplitViewColumnWidth(min: 180, ideal: 200, max: 240)
+            .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 260)
         } detail: {
             detailView(for: selectedPage)
         }
-        .frame(minWidth: 620, idealWidth: 700, minHeight: 420, idealHeight: 500)
+        .frame(minWidth: 720, idealWidth: 820, minHeight: 480, idealHeight: 560)
+        .onAppear {
+            // Sincroniza a aba inicial com o AppStorage que o MenuBar manipula
+            if let page = SettingsPage(rawValue: initialPageRaw) {
+                selectedPage = page
+            }
+        }
+        .onChange(of: initialPageRaw) { _, newValue in
+            if let page = SettingsPage(rawValue: newValue) {
+                selectedPage = page
+            }
+        }
+    }
+
+    private func pages(in section: SettingsPage.Section) -> [SettingsPage] {
+        SettingsPage.allCases.filter { $0.section == section }
     }
 
     @ViewBuilder
     private func detailView(for page: SettingsPage) -> some View {
         switch page {
+        case .overview:
+            OverviewPage()
         case .history:
             HistoryView(store: store)
-        case .audioFile:
-            AudioFileView(appState: appState, store: store)
         case .benchmark:
             BenchmarkView(appState: appState, store: benchmarkStore, historyStore: store)
         case .vocabulary:
@@ -180,289 +133,15 @@ struct SettingsView: View {
         case .correction:
             CorrectionPromptsView(appState: appState, store: correctionPromptStore)
         case .keyboard:
-            keyboardPage
+            KeyboardPage()
         case .microphone:
-            microphonePage
+            MicrophonePage()
         case .general:
-            generalPage
+            GeneralPage()
         case .permissions:
-            permissionsPage
+            PermissionsPage()
         case .about:
-            aboutPage
-        }
-    }
-
-    // MARK: - Atalhos de Teclado
-
-    private var keyboardPage: some View {
-        Form {
-            Section("Tecla de ativação") {
-                Picker("Tecla", selection: $activationKeyManager.selectedKey) {
-                    ForEach(ActivationKey.allCases) { key in
-                        Text(key.rawValue).tag(key)
-                    }
-                }
-
-                Picker("Modo", selection: $activationKeyManager.activationMode) {
-                    ForEach(ActivationMode.allCases, id: \.self) { mode in
-                        Text(mode.rawValue).tag(mode)
-                    }
-                }
-                .pickerStyle(.segmented)
-            }
-
-            Section {
-                KeyboardShortcuts.Recorder("Modo Prompt LLM:", name: .togglePromptMode)
-            } header: {
-                Text("Correção LLM")
-            } footer: {
-                Text("Atalho global para ligar/desligar o Modo Prompt. Quando ativo, o overlay fica visível com chips de prompts clicáveis. ESC também desliga.")
-            }
-
-            Section {
-                Toggle("Escape cancela gravação", isOn: $activationKeyManager.escapeToCancel)
-            } footer: {
-                Text("Toggle: toque para iniciar/parar · Hold: grave enquanto pressiona · Double Tap: toque duas vezes")
-            }
-        }
-        .formStyle(.grouped)
-        .navigationTitle("Atalhos de Teclado")
-    }
-
-    // MARK: - Microfone
-
-    /// ID do microfone que será usado na próxima gravação
-    private var preferredMicrophoneID: String? {
-        // Durante gravação, mostra o mic realmente ativo
-        if let activeID = microphoneManager.activeMicrophoneID {
-            return activeID
-        }
-        // Fora de gravação, mostra o primeiro conectado na ordem de prioridade
-        return microphoneManager.microphones.first(where: \.isConnected)?.id
-    }
-
-    private var microphonePage: some View {
-        Form {
-            Section {
-                Toggle("Usar padrão do sistema", isOn: $microphoneManager.useSystemDefault)
-            }
-
-            if !microphoneManager.useSystemDefault {
-                Section {
-                    // Em Form/.grouped no macOS, .onMove n\u00e3o oferece drag-to-reorder
-                    // nativo confi\u00e1vel. Usamos bot\u00f5es de seta como alternativa acess\u00edvel.
-                    ForEach(Array(microphoneManager.microphones.enumerated()), id: \.element.id) { index, mic in
-                        HStack {
-                            let isPreferred = mic.id == preferredMicrophoneID
-                            Image(systemName: isPreferred ? "mic.circle.fill" : (mic.isConnected ? "mic" : "mic.slash"))
-                                .foregroundStyle(isPreferred ? .green : (mic.isConnected ? .primary : .secondary))
-                            Text(mic.name)
-                                .foregroundStyle(mic.isConnected ? .primary : .secondary)
-                            Spacer()
-                            Button {
-                                microphoneManager.reorder(
-                                    fromOffsets: IndexSet(integer: index),
-                                    toOffset: index - 1
-                                )
-                            } label: {
-                                Image(systemName: "chevron.up")
-                            }
-                            .buttonStyle(.borderless)
-                            .disabled(index == 0)
-                            .help("Mover para cima")
-
-                            Button {
-                                microphoneManager.reorder(
-                                    fromOffsets: IndexSet(integer: index),
-                                    toOffset: index + 2
-                                )
-                            } label: {
-                                Image(systemName: "chevron.down")
-                            }
-                            .buttonStyle(.borderless)
-                            .disabled(index == microphoneManager.microphones.count - 1)
-                            .help("Mover para baixo")
-                        }
-                    }
-                } header: {
-                    Text("Ordem de prioridade")
-                } footer: {
-                    Text("Microfones são tentados na ordem acima. Use as setas para reordenar.")
-                }
-            }
-        }
-        .formStyle(.grouped)
-        .navigationTitle("Microfone")
-    }
-
-    // MARK: - Geral
-
-    private var generalPage: some View {
-        Form {
-            Section {
-                LaunchAtLogin.Toggle("Iniciar com o sistema")
-            }
-        }
-        .formStyle(.grouped)
-        .navigationTitle("Geral")
-    }
-
-    // MARK: - Permissões
-
-    private var permissionsPage: some View {
-        Form {
-            Section {
-                HStack {
-                    Label {
-                        Text("Microfone")
-                    } icon: {
-                        Image(systemName: microphoneStatusIcon)
-                            .foregroundStyle(microphoneStatusColor)
-                    }
-
-                    Spacer()
-
-                    if microphoneManager.isPermissionGranted {
-                        Text("Ativo")
-                            .font(.caption)
-                            .foregroundStyle(.green)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 2)
-                            .background(.green.opacity(0.1), in: Capsule())
-                    } else if microphoneManager.permissionState == .notDetermined {
-                        Button("Solicitar Permissão") {
-                            Task {
-                                _ = await microphoneManager.requestPermissionIfNeeded()
-                            }
-                        }
-                    } else if microphoneManager.permissionState != .unavailable {
-                        Button("Abrir Ajustes do Sistema") {
-                            microphoneManager.openSystemSettings()
-                        }
-                    }
-                }
-            } footer: {
-                Text(microphonePermissionFooter)
-            }
-
-            Section {
-                HStack {
-                    Label {
-                        Text("Acessibilidade")
-                    } icon: {
-                        Image(systemName: accessibilityManager.isGranted
-                              ? "checkmark.circle.fill"
-                              : "exclamationmark.triangle.fill")
-                            .foregroundStyle(accessibilityManager.isGranted ? .green : .orange)
-                    }
-
-                    Spacer()
-
-                    if accessibilityManager.isGranted {
-                        Text("Ativo")
-                            .font(.caption)
-                            .foregroundStyle(.green)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 2)
-                            .background(.green.opacity(0.1), in: Capsule())
-                    } else {
-                        Button("Abrir Ajustes do Sistema") {
-                            accessibilityManager.openSystemSettings()
-                        }
-                    }
-                }
-            } footer: {
-                Text("Necessário para colar no app ativo e para a hotkey global. Sem isso, a transcrição continua funcionando com cópia para o clipboard.")
-            }
-
-            if microphoneManager.permissionState == .unavailable {
-                Section("Bundle") {
-                    Text("O produto atual está sendo gerado como executável SwiftPM, sem `Info.plist` embutido. Nesse modo, o macOS não expõe a permissão de microfone de forma confiável.")
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                }
-            }
-
-            if !microphoneManager.isPermissionGranted && microphoneManager.permissionState != .unavailable {
-                Section("Como ativar o microfone") {
-                    Label("Clique em \"Solicitar Permissão\" ou inicie uma gravação", systemImage: "1.circle")
-                    Label("Se o macOS negar, abra Ajustes do Sistema", systemImage: "2.circle")
-                    Label("Ative zspeak em Privacidade → Microfone", systemImage: "3.circle")
-                }
-            }
-
-            if !accessibilityManager.isGranted {
-                Section("Como ativar") {
-                    Label("Clique em \"Abrir Ajustes do Sistema\"", systemImage: "1.circle")
-                    Label("Encontre \"zspeak\" na lista", systemImage: "2.circle")
-                    Label("Ative o toggle", systemImage: "3.circle")
-                }
-
-                Section("Resolução de problemas") {
-                    Text("Se zspeak não aparece na lista: clique \"+\" e navegue até /Applications/zspeak.app")
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                    Text("Se o toggle está ativo mas aqui mostra inativo: remova da lista, adicione novamente e reinicie o app.")
-                        .font(.callout)
-                        .foregroundStyle(.secondary)
-                }
-            }
-        }
-        .formStyle(.grouped)
-        .navigationTitle("Permissões")
-    }
-
-    // MARK: - Sobre
-
-    private var aboutPage: some View {
-        Form {
-            Section {
-                LabeledContent("Modelo", value: "Parakeet TDT 0.6B V3")
-                LabeledContent("Motor", value: "FluidAudio (CoreML/ANE)")
-                LabeledContent("Processamento", value: "100% local")
-            }
-
-            Section {
-                LabeledContent("Plataforma", value: "macOS 14+ (Apple Silicon)")
-                LabeledContent("Privacidade", value: "Nenhum dado sai do dispositivo")
-            }
-        }
-        .formStyle(.grouped)
-        .navigationTitle("Sobre")
-    }
-
-    private var microphoneStatusIcon: String {
-        switch microphoneManager.permissionState {
-        case .authorized:
-            return "checkmark.circle.fill"
-        case .notDetermined:
-            return "questionmark.circle.fill"
-        case .denied, .restricted, .unavailable:
-            return "exclamationmark.triangle.fill"
-        }
-    }
-
-    private var microphoneStatusColor: Color {
-        switch microphoneManager.permissionState {
-        case .authorized:
-            return .green
-        case .notDetermined:
-            return .yellow
-        case .denied, .restricted, .unavailable:
-            return .orange
-        }
-    }
-
-    private var microphonePermissionFooter: String {
-        switch microphoneManager.permissionState {
-        case .authorized:
-            return "Obrigatório para capturar sua voz e iniciar a transcrição."
-        case .notDetermined:
-            return "A primeira gravação vai solicitar acesso ao microfone."
-        case .denied, .restricted:
-            return "Sem acesso ao microfone a gravação não inicia."
-        case .unavailable:
-            return "O bundle atual não expõe `NSMicrophoneUsageDescription`, então o macOS não consegue liberar o microfone."
+            AboutPage()
         }
     }
 }

--- a/zspeak/Views/VocabularyView.swift
+++ b/zspeak/Views/VocabularyView.swift
@@ -1,88 +1,70 @@
 import SwiftUI
 
-/// Tela de gerenciamento de vocabulário customizado para context biasing
+/// Tela de gerenciamento de vocabulário customizado para context biasing.
+///
+/// Layout:
+/// - Busca no topo filtra por termo ou alias
+/// - Cada termo é um `DisclosureGroup`: colapsado mostra termo + qtd aliases + badge ativo/inativo
+/// - Expandido mostra aliases editáveis, slider de peso (1–20), toggle e botão apagar
+/// - Autosave debounced (300ms) persiste mudanças no store e reaplica vocabulário no modelo
+/// - Empty state com CTA
 struct VocabularyView: View {
     let appState: AppState
     @Bindable var store: VocabularyStore
 
-    @State private var isApplying = false
     @State private var entryToDelete: VocabularyEntry?
     @State private var applyError: String?
+    @State private var searchText: String = ""
+    @State private var expandedIDs: Set<UUID> = []
+
+    /// Token incrementado a cada mutação do snapshot de entries. Usado com `.task(id:)`
+    /// para disparar um único debounce de 300ms por rajada de edições.
+    @State private var autosaveToken: Int = 0
+
+    // MARK: - Body
 
     var body: some View {
         Form {
             if store.entries.isEmpty {
-                ContentUnavailableView(
-                    "Nenhum termo",
-                    systemImage: "text.book.closed",
-                    description: Text("Adicione termos para melhorar a precisão da transcrição.")
-                )
+                emptyStateSection
             } else {
-                ForEach(Array(store.entries.enumerated()), id: \.element.id) { index, entry in
+                ForEach(filteredIndices, id: \.self) { index in
+                    entrySection(at: index)
+                }
+
+                if !filteredIndices.isEmpty && filteredIndices.count < store.entries.count {
                     Section {
-                        TextField("Termo correto", text: $store.entries[index].term)
+                        Text("Mostrando \(filteredIndices.count) de \(store.entries.count) termos")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
 
-                        // Aliases
-                        Section("Aliases") {
-                            ForEach(Array(store.entries[index].aliases.enumerated()), id: \.offset) { aliasIndex, _ in
-                                HStack {
-                                    TextField("Alias", text: $store.entries[index].aliases[aliasIndex])
-                                    Button {
-                                        store.entries[index].aliases.remove(at: aliasIndex)
-                                    } label: {
-                                        Image(systemName: "xmark.circle.fill")
-                                            .foregroundStyle(.secondary)
-                                    }
-                                    .buttonStyle(.borderless)
-                                }
-                            }
-
-                            Button("Adicionar alias") {
-                                store.entries[index].aliases.append("")
-                            }
-                        }
-
-                        LabeledContent("Peso") {
-                            TextField("Peso", value: $store.entries[index].weight, format: .number)
-                                .textFieldStyle(.roundedBorder)
-                                .frame(width: 80)
-                        }
-
-                        Toggle("Ativo", isOn: $store.entries[index].isEnabled)
-
-                        Button("Apagar", role: .destructive) {
-                            entryToDelete = entry
-                        }
+                if filteredIndices.isEmpty && !searchText.isEmpty {
+                    Section {
+                        ContentUnavailableView.search(text: searchText)
                     }
                 }
             }
 
             if let applyError {
-                Label(applyError, systemImage: "exclamationmark.triangle.fill")
-                    .foregroundStyle(.red)
+                Section {
+                    Label(applyError, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.red)
+                        .font(.callout)
+                }
             }
         }
         .formStyle(.grouped)
         .navigationTitle("Vocabulário")
+        .searchable(text: $searchText, placement: .toolbar, prompt: "Buscar termo ou alias")
         .toolbar {
-            ToolbarItemGroup {
+            ToolbarItem {
                 Button {
-                    store.addEntry(term: "", aliases: [], weight: 10.0)
+                    addNewEntry()
                 } label: {
                     Label("Adicionar Termo", systemImage: "plus")
                 }
-
-                Button {
-                    applyVocabulary()
-                } label: {
-                    if isApplying {
-                        ProgressView()
-                            .controlSize(.small)
-                    } else {
-                        Label("Aplicar", systemImage: "checkmark.circle")
-                    }
-                }
-                .disabled(isApplying || !appState.isModelReady)
             }
         }
         .alert("Apagar termo?", isPresented: .init(
@@ -93,25 +75,237 @@ struct VocabularyView: View {
             Button("Apagar", role: .destructive) {
                 if let entry = entryToDelete {
                     store.deleteEntry(entry)
+                    expandedIDs.remove(entry.id)
                     entryToDelete = nil
+                    scheduleAutosave()
                 }
             }
         } message: {
             Text("Esta ação não pode ser desfeita.")
         }
+        .onChange(of: entriesFingerprint) { _, _ in
+            scheduleAutosave()
+        }
+        .task(id: autosaveToken) {
+            // Debounce: 300ms após última mutação antes de persistir e reaplicar.
+            guard autosaveToken > 0 else { return }
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            guard !Task.isCancelled else { return }
+            await persistAndReapply()
+        }
     }
 
-    private func applyVocabulary() {
-        Task {
-            isApplying = true
-            applyError = nil
-            store.save()
-            do {
-                try await appState.applyVocabulary()
-            } catch {
-                applyError = error.localizedDescription
+    // MARK: - Sections
+
+    @ViewBuilder
+    private var emptyStateSection: some View {
+        Section {
+            ContentUnavailableView {
+                Label("Nenhum termo", systemImage: "text.book.closed")
+            } description: {
+                Text("Adicione termos para melhorar a precisão da transcrição.")
+            } actions: {
+                Button {
+                    addNewEntry()
+                } label: {
+                    Label("Adicionar termo", systemImage: "plus")
+                }
+                .buttonStyle(.borderedProminent)
             }
-            isApplying = false
+        }
+    }
+
+    @ViewBuilder
+    private func entrySection(at index: Int) -> some View {
+        let entry = store.entries[index]
+        let isExpanded = Binding<Bool>(
+            get: { expandedIDs.contains(entry.id) },
+            set: { newValue in
+                if newValue { expandedIDs.insert(entry.id) }
+                else { expandedIDs.remove(entry.id) }
+            }
+        )
+
+        Section {
+            DisclosureGroup(isExpanded: isExpanded) {
+                expandedBody(for: index)
+            } label: {
+                collapsedLabel(for: entry)
+            }
+        }
+        .listRowBackground(
+            isExpanded.wrappedValue
+                ? RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(Color.accentColor.opacity(0.25), lineWidth: 1)
+                    .background(RoundedRectangle(cornerRadius: 8).fill(Color.clear))
+                : nil
+        )
+    }
+
+    @ViewBuilder
+    private func collapsedLabel(for entry: VocabularyEntry) -> some View {
+        HStack(spacing: 8) {
+            Text(entry.term.isEmpty ? "(sem nome)" : entry.term)
+                .font(.body)
+                .foregroundStyle(entry.term.isEmpty ? .secondary : .primary)
+                .lineLimit(1)
+
+            Spacer()
+
+            if !entry.aliases.isEmpty {
+                Text("\(entry.aliases.count) \(entry.aliases.count == 1 ? "alias" : "aliases")")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            badge(isEnabled: entry.isEnabled)
+        }
+    }
+
+    @ViewBuilder
+    private func badge(isEnabled: Bool) -> some View {
+        Text(isEnabled ? "Ativo" : "Inativo")
+            .font(.caption2.weight(.medium))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+                Capsule()
+                    .fill(isEnabled ? Color.green.opacity(0.2) : Color.gray.opacity(0.2))
+            )
+            .foregroundStyle(isEnabled ? Color.green : Color.secondary)
+    }
+
+    @ViewBuilder
+    private func expandedBody(for index: Int) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Termo
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Termo")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                TextField("Termo correto", text: $store.entries[index].term)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            Divider()
+
+            // Aliases
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Aliases")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                ForEach(store.entries[index].aliases.indices, id: \.self) { aliasIndex in
+                    HStack {
+                        TextField("Alias", text: $store.entries[index].aliases[aliasIndex])
+                            .textFieldStyle(.roundedBorder)
+                        Button {
+                            guard aliasIndex < store.entries[index].aliases.count else { return }
+                            store.entries[index].aliases.remove(at: aliasIndex)
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.borderless)
+                    }
+                }
+
+                Button {
+                    store.entries[index].aliases.append("")
+                } label: {
+                    Label("Adicionar alias", systemImage: "plus.circle")
+                        .font(.callout)
+                }
+                .buttonStyle(.borderless)
+            }
+
+            Divider()
+
+            // Peso via slider 1–20
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text("Peso")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text(String(format: "%.0f", store.entries[index].weight))
+                        .font(.callout.monospacedDigit())
+                        .foregroundStyle(.primary)
+                        .frame(minWidth: 24, alignment: .trailing)
+                }
+                Slider(
+                    value: $store.entries[index].weight,
+                    in: 1...20,
+                    step: 1
+                )
+                Text("Valores maiores aumentam a probabilidade do modelo preferir este termo.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+
+            Divider()
+
+            Toggle("Ativo", isOn: $store.entries[index].isEnabled)
+
+            HStack {
+                Spacer()
+                Button(role: .destructive) {
+                    entryToDelete = store.entries[index]
+                } label: {
+                    Label("Apagar", systemImage: "trash")
+                }
+                .buttonStyle(.borderless)
+                .foregroundStyle(.red)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - Ações
+
+    /// "Fingerprint" Equatable derivado das entries, já que `VocabularyEntry` não conforma Equatable.
+    /// Muda sempre que term, aliases, weight ou isEnabled mudam — cobre todas as edições inline.
+    private var entriesFingerprint: String {
+        store.entries.reduce(into: "") { acc, entry in
+            acc += "\(entry.id.uuidString)|\(entry.term)|\(entry.isEnabled)|\(entry.weight)|\(entry.aliases.joined(separator: ","));"
+        }
+    }
+
+    /// Índices dos entries que batem com a busca atual. Sem filtro → todos.
+    private var filteredIndices: [Int] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !query.isEmpty else {
+            return Array(store.entries.indices)
+        }
+        return store.entries.indices.filter { idx in
+            let entry = store.entries[idx]
+            if entry.term.lowercased().contains(query) { return true }
+            return entry.aliases.contains { $0.lowercased().contains(query) }
+        }
+    }
+
+    private func addNewEntry() {
+        store.addEntry(term: "", aliases: [], weight: 10.0)
+        if let newID = store.entries.last?.id {
+            expandedIDs.insert(newID)
+        }
+        scheduleAutosave()
+    }
+
+    /// Dispara uma nova janela de debounce — `.task(id:)` reinicia com o token novo.
+    private func scheduleAutosave() {
+        autosaveToken &+= 1
+    }
+
+    /// Persiste no disco e reaplica o vocabulário no modelo (se estiver pronto).
+    private func persistAndReapply() async {
+        store.save()
+        applyError = nil
+        guard appState.isModelReady else { return }
+        do {
+            try await appState.applyVocabulary()
+        } catch {
+            applyError = error.localizedDescription
         }
     }
 }


### PR DESCRIPTION
## Sumário

Overhaul completo da janela de Configurações em 1 PR. Fix do merge incompleto da Onda 3 (duas janelas coexistindo) + nova arquitetura de informação + polimento visual em todas as páginas.

### P0 — Consolidação
- `SettingsWindowController` removido inteiro
- `MenuBarView` usa `openSettings()` + `@AppStorage` pra aba inicial
- Dependências via `.environment(_:)` (era 8 parâmetros manuais)

### P1 — Arquitetura de informação
- Sidebar agrupada: Conteúdo / Configurações / Sistema
- Nova aba "Visão Geral" como default
- "Transcrever arquivo" vira janela dedicada

### P2 + P3 — Polimento
- **Histórico:** agrupamento por data, busca, layout denso
- **Vocabulário:** DisclosureGroup, slider de peso, autosave sem botão
- **Correção LLM:** modelo compacto, templates de prompt
- **Benchmark:** card agregado, progresso de runAll, erros por fixture
- **Atalhos:** preview visual do atalho
- **Microfone:** drag-to-reorder, badges Ativo/Preferido
- **Geral:** novas opções (pasteMode, sons, latência)
- **Permissões:** header agregado, mensagens amigáveis
- **Sobre:** logo, versão do Bundle, link GitHub

### ErrorMapper
Criado em `zspeak/ErrorMapper.swift` mapeando OSStatus CoreAudio para mensagens em português. Pronto, não plugado ainda.

## Plano de testes manuais
- [ ] Cmd+, e clicar "Configurações..." no menu abrem a MESMA janela
- [ ] Cmd+Shift+T abre janela "Transcrever arquivo" separada
- [ ] Visão Geral mostra status agregado
- [ ] Histórico: buscar e agrupar por data
- [ ] Vocabulário: editar termo expande, slider de peso funciona, autosave
- [ ] Correção LLM: download mostra progresso, templates criam prompts
- [ ] Benchmark: rodar todos mostra barra de progresso, parar cancela
- [ ] Microfone: arrastar pra reordenar
- [ ] Permissões: header verde quando tudo OK

223/224 testes passando. Falha pré-existente em hardware ("Fast path com warmUp" timing-dependent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)